### PR TITLE
Replace pre-install block in Expo plugin with post-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+## 9.0.1
+
+Fix build issue on iOS ([#29](https://github.com/maplibre/maplibre-react-native/issues/29))
+
 ## 9.0.0
 
 Completed fork from RNMapbox, removed support for the proprietary Mapbox SDK, and updated to the latest

--- a/plugin/src/withMapLibre.ts
+++ b/plugin/src/withMapLibre.ts
@@ -55,10 +55,10 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin = c => {
 // used for spm (swift package manager) which Expo doesn't currently support.
 export function applyCocoaPodsModifications(contents: string): string {
   // Ensure installer blocks exist
-  let src = addInstallerBlock(contents, 'pre');
-  // src = addInstallerBlock(src, "post");
-  src = addMapLibreInstallerBlock(src, 'pre');
-  // src = addMapLibreInstallerBlock(src, "post");
+  // let src = addInstallerBlock(contents, 'pre');
+  let src = addInstallerBlock(contents, 'post');
+  // src = addMapLibreInstallerBlock(src, 'pre');
+  src = addMapLibreInstallerBlock(src, 'post');
   return src;
 }
 


### PR DESCRIPTION
## Description

Fixes [#29](https://github.com/maplibre/maplibre-react-native/issues/29)

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
- [x] I added/updated a sample (`/example`)
