### PR TITLE
fix: plugin for debug simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+fix: plugin for debug simulator ([#164](https://github.com/maplibre/maplibre-react-native/pull/164)
+
 ## 10.0-alpha.0
 
 chore: update detox ([#207](https://github.com/maplibre/maplibre-react-native/pull/207))

--- a/plugin/src/withMapLibre.ts
+++ b/plugin/src/withMapLibre.ts
@@ -117,10 +117,13 @@ export function setExcludedArchitectures(project: XcodeProject): XcodeProject {
   const configurations = project.pbxXCBuildConfigurationSection();
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  for (const {buildSettings} of Object.values(configurations || {})) {
+  for (const {name, buildSettings} of Object.values(configurations || {})) {
     // Guessing that this is the best way to emulate Xcode.
     // Using `project.addToBuildSettings` modifies too many targets.
-    if (typeof buildSettings?.PRODUCT_NAME !== 'undefined') {
+    if (
+      name === 'Release' &&
+      typeof buildSettings?.PRODUCT_NAME !== 'undefined'
+    ) {
       buildSettings['"EXCLUDED_ARCHS[sdk=iphonesimulator*]"'] = '"arm64"';
     }
   }


### PR DESCRIPTION
Only set EXCLUDED_ARCHS for Release Build Settings

Enables M1/M2’s to build in debug mode simulator, without having to open Xcode and configure the project settings manually.

Closes #136