### PR TITLE
update release note & version in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+## 10.0-alpha.0
+
 chore: update detox ([#207](https://github.com/maplibre/maplibre-react-native/pull/207))
 chore: update expo-config and expo-scripts ([#47](https://github.com/maplibre/maplibre-react-native/pull/104) and [#69](https://github.com/maplibre/maplibre-react-native/pull/69))
 chore: update prettier and eslint-plugin-prettier ([#111](https://github.com/maplibre/maplibre-react-native/pull/111))
+feat: **breaking** migrate repo to typescript ([#55](https://github.com/maplibre/maplibre-react-native/pull/55))
 
 ## 9.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-react-native",
   "description": "A MapLibre GL Native plugin for creating maps in React Native",
-  "version": "9.1.0",
+  "version": "10.0-alpha.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Release of the typescript feature. As an alpha release as the api may be breaking. See https://github.com/maplibre/maplibre-react-native/pull/52#issuecomment-1713228977