### PR TITLE
Fix 'Could not find com.facebook.react:react-android' on RN < .71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
+fix(android): Fix 'Could not find com.facebook.react:react-android' on RN < .71 [#236](https://github.com/maplibre/maplibre-react-native/pull/236)
 
 ## 10.0-alpha.0
 

--- a/android/install.md
+++ b/android/install.md
@@ -29,3 +29,9 @@ import MapLibreGL from "@maplibre/maplibre-react-native";
 
 MapLibreGL.setConnected(true);
 ```
+## React Native older than 0.71
+If the React Native version is older than 0.71 and the React Native location can't be detected, you need to add the following to your `android/app/build.gradle` file:
+
+```gradle
+REACT_NATIVE_NODE_MODULES_DIR=[location of node_modules (e.g ../../node_modules)]
+```

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -1,8 +1,46 @@
+import java.nio.file.Files
 apply plugin: 'com.android.library'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
+
+def resolveReactNativeDirectory() {
+    def reactNativeLocation = safeExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
+    if (reactNativeLocation != null) {
+        return file(reactNativeLocation)
+    }
+
+    // monorepo workaround
+    // react-native can be hoisted or in project's own node_modules
+    def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
+    if (reactNativeFromProjectNodeModules.exists()) {
+        return reactNativeFromProjectNodeModules
+    }
+
+    def reactNativeFromNodeModulesWithReanimated = file("${projectDir}/../../react-native")
+    if (reactNativeFromNodeModulesWithReanimated.exists()) {
+        return reactNativeFromNodeModulesWithReanimated
+    }
+
+    throw new Exception(
+        "[maplibre-react-native] Unable to resolve react-native location in " +
+            "node_modules. You should add project extension property (in app/build.gradle) " +
+            "`REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+    )
+}
+
+def getReactNativeMinorVersion() {
+    def REACT_NATIVE_DIR = resolveReactNativeDirectory()
+
+    def reactProperties = new Properties()
+    file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+
+    def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
+    return REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
+}
+
+def REACT_NATIVE_MINOR_VERSION = getReactNativeMinorVersion()
 
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 33)
@@ -30,7 +68,12 @@ android {
 
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
-    implementation("com.facebook.react:react-android")
+    if (REACT_NATIVE_MINOR_VERSION >= 71) {
+        implementation "com.facebook.react:react-android" // version substituted by RNGP
+    } else {
+        implementation 'com.facebook.react:react-native:+' // from node_modules for pre RN 0.71
+    }
+
 
     // MapLibre SDK
     implementation "org.maplibre.gl:android-sdk:9.6.0"


### PR DESCRIPTION


## Description

Fixes #[<231>](https://github.com/maplibre/maplibre-react-native/issues/231)

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [X] I have run tests via `yarn test` in the root folder
- [X] I updated the documentation with running `yarn generate` in the root folder
- [X] I mentioned this change in `CHANGELOG.md`


