### PR TITLE
Fix: Duplicated Signature issue with Xcode 15 #12022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+Fix: Duplicated Signature issue with Xcode 15 ([#238](https://github.com/maplibre/maplibre-react-native/pull/238)): Fixes [CocoaPods/issues/12022](https://github.com/CocoaPods/CocoaPods/issues/12022)
 chore: update support libraries ([#121](https://github.com/maplibre/maplibre-react-native/pull/121)).
 
 ## 10.0.0-alpha.1


### PR DESCRIPTION
## Description

The library fails in Expo with Xcode 15 due to CocoaPods/issues/12022

This PR addresses the issue by delete the duplicate signature file in the build phase.

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [X] I have run tests via `yarn test` in the root folder
- [X] I updated the documentation with running `yarn generate` in the root folder
- [X] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/updated a sample (`/example`)
