### PR TITLE
fix: remove AbortController test mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ PR Title ([#123](link to my pr))
 ```
 
 Fix: [android example crashing](https://github.com/maplibre/maplibre-react-native/pull/372) on launch
+Fix: [remove AbortController test mock](https://github.com/maplibre/maplibre-react-native/pull/403)
 
 ## 10.0.0-alpha.4
 Update maplibre-native to use [new metal renderer on iOS](https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.4.0)

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -106,9 +106,3 @@ NativeModules.MLNLocationModule = {
   stop: jest.fn(),
   pause: jest.fn(),
 };
-
-// Mock for global AbortController
-global.AbortController = class {
-  signal = 'test-signal';
-  abort = jest.fn();
-};


### PR DESCRIPTION
## Description

[This change was recently made in rnmapbox.][0]

This library includes an `AbortController` test mock, which doesn't work in places that expect a real one. For example, I was writing an unrelated test that tried to cancel a `fetch()` which failed because the `AbortController`'s `signal` property was invalid.

Because [`AbortController` is in all supported Node versions][1], we can safely remove this mock and rely on the real thing.

This should only affect tests.

## Checklist

- [ ] ~~I have tested this on a device/simulator for each compatible OS~~
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I have run tests via `yarn test` in the root folder
- [ ] ~~I updated the documentation with running `yarn generate` in the root folder~~
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] ~~I updated the typings files (`index.d.ts`)~~
- [ ] ~~I added/updated a sample (`/example`)~~

[0]: https://github.com/rnmapbox/maps/commit/5b6489e2bffe509ff26fbdc054b693682bcdb31e
[1]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility
