### PR TITLE
fix: setMaxAnimationFps on null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ PR Title ([#123](link to my pr))
 
 ```
 
+fix: [fix: setMaxAnimationFps on null]([#440](https://github.com/maplibre/maplibre-react-native/pull/440))
+
 ## 10.0.0-alpha.12
 
 Specify in install.md the correct SPM variable name to use a different native iOS library version

--- a/android/rctmln/src/main/java/com/maplibre/rctmln/components/location/LocationComponentManager.java
+++ b/android/rctmln/src/main/java/com/maplibre/rctmln/components/location/LocationComponentManager.java
@@ -68,7 +68,7 @@ public class LocationComponentManager {
     }
 
     public void setPreferredFramesPerSecond(int preferredFramesPerSecond) {
-       if(preferredFramesPerSecond <= 0) {
+       if(mLocationComponent == null || preferredFramesPerSecond <= 0) {
             return;
        }
 


### PR DESCRIPTION
I successfully reproduced and fixed below bug

## Description

Fixes #439 

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [X] I have run tests via `yarn test` in the root folder
- [n/a] I updated the documentation with running `yarn generate` in the root folder
- [X] I mentioned this change in `CHANGELOG.md`
- [n/a] I updated the typings files (`index.d.ts`)
- [n/a] I added/updated a sample (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
