### PR TITLE
fix: make MarkerView props with defaults optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ PR Title ([#123](link to my pr))
 
 ```
 
-fix: make MarkerView props with defaults optional ([#460](https://github.com/maplibre/maplibre-react-native/pull/460)
+fix: make MarkerView props with defaults optional ([#460](https://github.com/maplibre/maplibre-react-native/pull/460))
 
 ## 10.0.0-alpha.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ PR Title ([#123](link to my pr))
 
 ```
 
-fix: make MarkerView props with defaults optional (#460)
+fix: make MarkerView props with defaults optional ([#460](https://github.com/maplibre/maplibre-react-native/pull/460)
 
 ## 10.0.0-alpha.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ PR Title ([#123](link to my pr))
 
 ```
 
+fix: make MarkerView props with defaults optional (#460)
+
 ## 10.0.0-alpha.17
 
 fix: [add generic expo plugin to remove Duplicated Signature in Xcode 15/16](<[#453](https://github.com/maplibre/maplibre-react-native/pull/453)>)

--- a/javascript/components/MarkerView.tsx
+++ b/javascript/components/MarkerView.tsx
@@ -20,7 +20,7 @@ interface MarkerViewProps extends ViewProps {
    * Note this is only for custom annotations not the default pin view.
    * Defaults to the center of the view.
    */
-  anchor: {
+  anchor?: {
     /**
      * `x` of anchor
      */
@@ -30,8 +30,8 @@ interface MarkerViewProps extends ViewProps {
      */
     y: number;
   };
-  allowOverlap: boolean;
-  isSelected: boolean;
+  allowOverlap?: boolean;
+  isSelected?: boolean;
   /**
    * Expects one child - can be container with multiple elements
    */


### PR DESCRIPTION
## Description

`MarkerViewProps` are currently wrongly typed. There are props with defaults but the types are required. It's also a mismatch with the docs.

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I have run tests via `yarn test` in the root folder
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/updated a sample (`/example`)
