### PR TITLE
fix: updated Mapbox callstack check for iOS custom headers to check for MapLibre instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ PR Title ([#123](link to my pr))
 
 ```
 
+fix: updated Mapbox callstack check for iOS custom headers to check for MapLibre instead [#461](https://github.com/maplibre/maplibre-react-native/pull/461)
+
 ## 10.0.0-alpha.17
 
 fix: [add generic expo plugin to remove Duplicated Signature in Xcode 15/16](<[#453](https://github.com/maplibre/maplibre-react-native/pull/453)>)

--- a/ios/RCTMLN/MLNCustomHeaders.m
+++ b/ios/RCTMLN/MLNCustomHeaders.m
@@ -21,7 +21,7 @@
             return [NSMutableURLRequest __swizzle_requestWithURL:url];
         }
 
-        if ([stack[1] containsString:@"Mapbox"] == NO) {
+        if ([stack[1] containsString:@"MapLibre"] == NO) {
             return [NSMutableURLRequest __swizzle_requestWithURL:url];
         }
 


### PR DESCRIPTION
## Description

On iOS, `MLNCustomHeaders` checks the callstack for `Mapbox` to determine whether or not to intercept a request and add custom headers to it, however `Mapbox` is not present in the callstack for requests made by MapLibre, meaning that no request is ever intercepted.

This PR updates the check to look for `MapLibre` instead, which is present in the callstack, and results in requests made by MapLibre successfully being intercepted.

Apologies for some of the open tasks below, I struggled with parts of the local setup and am new to contributing to OSS. Feedback and help is very welcome and much appreciated :)

Thank you!

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [ ] I have run tests via `yarn test` in the root folder
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [X] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/updated a sample (`/example`)
