### PR TITLE
fix: allow resetting contentInset with 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ PR Title ([#123](link to my pr))
 
 ```
 
+fix: allow resetting contentInset with 0 ([#468](https://github.com/maplibre/maplibre-react-native/pull/468))
+
 ## 10.0.0-alpha.21
 
 fix: Call requestProgress when getting pack status on IOS + example improvement [#445](https://github.com/maplibre/maplibre-react-native/pull/445)

--- a/javascript/components/MapView.tsx
+++ b/javascript/components/MapView.tsx
@@ -760,7 +760,7 @@ const MapView = memo(
       };
 
       const contentInsetValue = useMemo(() => {
-        if (!props.contentInset) {
+        if (props.contentInset === undefined) {
           return;
         }
 

--- a/javascript/components/MapView.tsx
+++ b/javascript/components/MapView.tsx
@@ -812,7 +812,7 @@ const MapView = memo(
           surfaceView,
           regionWillChangeDebounceTime,
           regionDidChangeDebounceTime,
-          contentInsetValue,
+          contentInset: contentInsetValue,
           style: styles.matchParent,
         };
       }, [
@@ -825,7 +825,6 @@ const MapView = memo(
         surfaceView,
         regionWillChangeDebounceTime,
         regionDidChangeDebounceTime,
-        contentInsetValue,
         props,
         contentInsetValue,
       ]);


### PR DESCRIPTION
## Description

To be able to reset `contentInset` we should accept `0` as a new value. Also the `contentInsetValue` wasn't passed as the correct native prop `contentInset`.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I have run tests via `yarn test` in the root folder
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/updated a sample (`/example`)
