### PR TITLE
feat: supporting apps that have enabled New Architecture

### DIFF
--- a/android/rctmln/src/main/java/com/maplibre/rctmln/components/AbstractEventEmitter.java
+++ b/android/rctmln/src/main/java/com/maplibre/rctmln/components/AbstractEventEmitter.java
@@ -10,6 +10,9 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.maplibre.rctmln.events.IEvent;
 
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.common.UIManagerType;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +48,8 @@ abstract public class AbstractEventEmitter<T extends ViewGroup> extends ViewGrou
 
     @Override
     protected void addEventEmitters(ThemedReactContext context, @Nonnull T view) {
-        mEventDispatcher = context.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        // Replace deprecated UIManagerModule with UIManager (via UIManagerHelper)
+        mEventDispatcher = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC).getEventDispatcher();
     }
 
     @Nullable

--- a/javascript/components/Camera.tsx
+++ b/javascript/components/Camera.tsx
@@ -8,13 +8,17 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import { NativeModules, requireNativeComponent, ViewProps } from "react-native";
+import { NativeModules, Platform, requireNativeComponent, ViewProps } from "react-native";
 
 import { useNativeRef } from "../hooks/useNativeRef";
 import { MaplibreGLEvent } from "../types";
 import { makeNativeBounds } from "../utils/makeNativeBounds";
 
-const MapLibreGL = NativeModules.MLNModule;
+// Android cannot access the MLNModule for some reason, so we need to access the RCTMLNModule directly
+const MapLibreGL = Platform.select({
+  ios: NativeModules.MLNModule,
+  android: NativeModules.RCTMLNModule,
+});
 
 export const NATIVE_MODULE_NAME = "RCTMLNCamera";
 

--- a/javascript/components/MapView.tsx
+++ b/javascript/components/MapView.tsx
@@ -19,6 +19,7 @@ import {
   ViewProps,
   NativeMethods,
   NativeSyntheticEvent,
+  Platform,
 } from "react-native";
 
 import useNativeBridge from "../hooks/useNativeBridge";
@@ -30,7 +31,12 @@ import Logger from "../utils/Logger";
 import { FilterExpression } from "../utils/MaplibreStyles";
 import { getFilter } from "../utils/filterUtils";
 
-const MapLibreGL = NativeModules.MLNModule;
+// Android cannot access the MLNModule for some reason, so we need to access the RCTMLNModule directly
+const MapLibreGL = Platform.select({
+  ios: NativeModules.MLNModule,
+  android: NativeModules.RCTMLNModule,
+});
+
 if (MapLibreGL == null) {
   console.error(
     "Native module of @maplibre/maplibre-react-native library was not registered properly, please consult the docs: https://github.com/maplibre/maplibre-react-native",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,9 +15,9 @@
     "@react-native-masked-view/masked-view": "^0.3.1",
     "react": "18.2.0",
     "react-native": ">=0.74.0",
-    "react-native-gesture-handler": "^2.20.0",
+    "react-native-gesture-handler": "^2.16.1",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "^3.31.0"
   },
   "dependencies": {
     "@mapbox/geo-viewport": "^0.5.0",
@@ -38,9 +38,9 @@
     "@types/react": "^18.2.61",
     "react": "18.2.0",
     "react-native": "^0.74.6",
-    "react-native-gesture-handler": "^2.20.0",
+    "react-native-gesture-handler": "^2.16.1",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0",
+    "react-native-screens": "^3.31.0",
     "typescript": "^5.5.3"
   }
 }

--- a/packages/examples/src/App.tsx
+++ b/packages/examples/src/App.tsx
@@ -1,6 +1,13 @@
 import MapLibreGL from "@maplibre/maplibre-react-native";
 import React, { useEffect, useState } from "react";
-import { StyleSheet, Text, View, LogBox, NativeModules } from "react-native";
+import {
+  StyleSheet,
+  Text,
+  View,
+  LogBox,
+  NativeModules,
+  Platform,
+} from "react-native";
 import { SafeAreaView, SafeAreaProvider } from "react-native-safe-area-context";
 import "react-native-gesture-handler";
 
@@ -21,8 +28,12 @@ const styles = StyleSheet.create({
   },
 });
 
-// Can't access setAccessToken from MapLibreGL, so we need to access the native module directly
-NativeModules.RCTMLNModule.setAccessToken(null);
+// Android cannot access the MLNModule for some reason, so we need to access the RCTMLNModule directly
+if (Platform.OS === "android") {
+  NativeModules.RCTMLNModule.setAccessToken(null);
+} else {
+  NativeModules.MLNModule.setAccessToken(null);
+}
 
 export function App() {
   const [isFetchingAndroidPermission, setIsFetchingAndroidPermission] =

--- a/packages/examples/src/App.tsx
+++ b/packages/examples/src/App.tsx
@@ -1,6 +1,6 @@
 import MapLibreGL from "@maplibre/maplibre-react-native";
 import React, { useEffect, useState } from "react";
-import { StyleSheet, Text, View, LogBox } from "react-native";
+import { StyleSheet, Text, View, LogBox, NativeModules } from "react-native";
 import { SafeAreaView, SafeAreaProvider } from "react-native-safe-area-context";
 import "react-native-gesture-handler";
 
@@ -21,7 +21,8 @@ const styles = StyleSheet.create({
   },
 });
 
-MapLibreGL.setAccessToken(null);
+// Can't access setAccessToken from MapLibreGL, so we need to access the native module directly
+NativeModules.RCTMLNModule.setAccessToken(null);
 
 export function App() {
   const [isFetchingAndroidPermission, setIsFetchingAndroidPermission] =

--- a/packages/examples/src/examples/Map/ShowMap.tsx
+++ b/packages/examples/src/examples/Map/ShowMap.tsx
@@ -1,48 +1,76 @@
-import MapLibreGL from "@maplibre/maplibre-react-native";
+// import MapLibreGL from "@maplibre/maplibre-react-native";
 import React, { useEffect, useState } from "react";
-import { Alert } from "react-native";
+import { Alert, View } from "react-native";
 
-import sheet from "../../styles/sheet";
-import { onSortOptions } from "../../utils";
-import TabBarPage from "../common/TabBarPage";
+// import sheet from "../../styles/sheet";
+// import { onSortOptions } from "../../utils";
+// import TabBarPage from "../common/TabBarPage";
 
-const OPTIONS = Object.keys(MapLibreGL.StyleURL)
-  .map((key) => {
-    return {
-      label: key,
-      data: (MapLibreGL.StyleURL as any)[key], // bad any, because enums
-    };
-  })
-  .sort(onSortOptions);
+let MapLibreGL: any;
+try {
+  console.log("Attempting to import MapLibreGL");
+  MapLibreGL = require("@maplibre/maplibre-react-native");
+  // native modules do exist on MapLibreGL, but we can't access them from the JS side for some reason
+  console.log("Available Native Modules:", Object.keys(MapLibreGL));
+  console.log("MapLibreGL import successful");
+} catch (error) {
+  console.error("Error importing MapLibreGL:", error);
+}
+
+// const OPTIONS = Object.keys(MapLibreGL)
+//   .map((key) => {
+//     return {
+//       label: key,
+//       data: (MapLibreGL as any)[key], // bad any, because enums
+//     };
+//   })
+//   .sort(onSortOptions);
 
 export default function ShowMap() {
-  const [styleURL, setStyleURL] = useState(OPTIONS[0].data);
+  // const [styleURL, setStyleURL] = useState(OPTIONS[0].data);
 
-  useEffect(() => {
-    MapLibreGL.locationManager.start();
+  // useEffect(() => {
+  //   MapLibreGL.locationManager.start();
 
-    return (): void => {
-      MapLibreGL.locationManager.stop();
-    };
-  }, []);
+  //   return (): void => {
+  //     MapLibreGL.locationManager.stop();
+  //   };
+  // }, []);
 
   return (
-    <TabBarPage
-      scrollable
-      options={OPTIONS}
-      onOptionPress={(index, data): void => {
-        setStyleURL(data);
+    // <TabBarPage
+    //   scrollable
+    //   options={OPTIONS}
+    //   onOptionPress={(index, data): void => {
+    //     setStyleURL(data);
+    //   }}
+    // >
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: "blue",
       }}
     >
-      <MapLibreGL.MapView styleURL={styleURL} style={sheet.matchParent}>
-        <MapLibreGL.Camera followZoomLevel={6} followUserLocation />
-
-        <MapLibreGL.UserLocation
+      <MapLibreGL.MapView
+        style={{
+          flex: 1,
+          alignSelf: "stretch",
+        }}
+        logoEnabled={false}
+      >
+        <MapLibreGL.Camera
+          defaultSettings={{
+            centerCoordinate: [-2.15761, 53.40979],
+            zoomLevel: 5,
+          }}
+        />
+        {/* <MapLibreGL.UserLocation
           onPress={() => {
             Alert.alert("You pressed on the user location annotation");
           }}
-        />
+        /> */}
       </MapLibreGL.MapView>
-    </TabBarPage>
+    </View>
+    // </TabBarPage>
   );
 }

--- a/packages/expo-app/app.config.ts
+++ b/packages/expo-app/app.config.ts
@@ -26,5 +26,16 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   plugins: [
     ["expo-dev-launcher", { launchMode: "most-recent" }],
     "@maplibre/maplibre-react-native",
+    [
+      "expo-build-properties",
+      {
+        ios: {
+          newArchEnabled: true,
+        },
+        android: {
+          newArchEnabled: true,
+        },
+      },
+    ],
   ],
 });

--- a/packages/expo-app/package.json
+++ b/packages/expo-app/package.json
@@ -14,13 +14,14 @@
     "@maplibre/maplibre-react-native": "workspace:*",
     "@react-native-masked-view/masked-view": "^0.3.1",
     "expo": "^51.0.38",
+    "expo-build-properties": "~0.12.5",
     "expo-dev-client": "^4.0.28",
     "expo-status-bar": "^1.12.1",
     "react": "18.2.0",
-    "react-native": "^0.74.6",
-    "react-native-gesture-handler": "^2.20.1",
+    "react-native": "^0.74.5",
+    "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "3.31.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,17 +3164,17 @@ __metadata:
     moment: "npm:^2.30.1"
     react: "npm:18.2.0"
     react-native: "npm:^0.74.6"
-    react-native-gesture-handler: "npm:^2.20.0"
+    react-native-gesture-handler: "npm:^2.16.1"
     react-native-safe-area-context: "npm:^4.11.1"
-    react-native-screens: "npm:^3.34.0"
+    react-native-screens: "npm:^3.31.0"
     typescript: "npm:^5.5.3"
   peerDependencies:
     "@react-native-masked-view/masked-view": ^0.3.1
     react: 18.2.0
     react-native: ">=0.74.0"
-    react-native-gesture-handler: ^2.20.0
+    react-native-gesture-handler: ^2.16.1
     react-native-safe-area-context: ^4.11.1
-    react-native-screens: ^3.34.0
+    react-native-screens: ^3.31.0
   languageName: unknown
   linkType: soft
 
@@ -5422,7 +5422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.6.3":
+"ajv@npm:^8.11.0, ajv@npm:^8.6.3":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -8472,13 +8472,14 @@ __metadata:
     "@maplibre/maplibre-react-native": "workspace:*"
     "@react-native-masked-view/masked-view": "npm:^0.3.1"
     expo: "npm:^51.0.38"
+    expo-build-properties: "npm:~0.12.5"
     expo-dev-client: "npm:^4.0.28"
     expo-status-bar: "npm:^1.12.1"
     react: "npm:18.2.0"
-    react-native: "npm:^0.74.6"
-    react-native-gesture-handler: "npm:^2.20.1"
+    react-native: "npm:^0.74.5"
+    react-native-gesture-handler: "npm:~2.16.1"
     react-native-safe-area-context: "npm:^4.11.1"
-    react-native-screens: "npm:^3.34.0"
+    react-native-screens: "npm:3.31.1"
   languageName: unknown
   linkType: soft
 
@@ -8492,6 +8493,18 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10/6b1f90216ea5e2c785193528bdf2d5855f7089a39235149793130de77fa49b91ed4b6c131935e035598c08859b0fe0f7279a444f7c88d1261389dff303266409
+  languageName: node
+  linkType: hard
+
+"expo-build-properties@npm:~0.12.5":
+  version: 0.12.5
+  resolution: "expo-build-properties@npm:0.12.5"
+  dependencies:
+    ajv: "npm:^8.11.0"
+    semver: "npm:^7.6.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10/22a1c3fbe6ef00efe13976612766c665390df033d84203bb8d8133fec5d9291be333341119f35b4f5e60932b5829e9ac10c7aaa1a28cbfb5fa689b1b7917229a
   languageName: node
   linkType: hard
 
@@ -14362,9 +14375,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:^2.20.0":
-  version: 2.20.0
-  resolution: "react-native-gesture-handler@npm:2.20.0"
+"react-native-gesture-handler@npm:^2.16.1":
+  version: 2.20.2
+  resolution: "react-native-gesture-handler@npm:2.20.2"
   dependencies:
     "@egjs/hammerjs": "npm:^2.0.17"
     hoist-non-react-statics: "npm:^3.3.0"
@@ -14373,7 +14386,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/2b0d638e739534c862eefe4429d634e14f97872fbcd8d6069a1a6af8d6ba65c22f6b00298b3ed6b636f5ab376c23c40e719566313fe7aca304af29b3198a2190
+  checksum: 10/64ab125c539ca8c275f5d305f5e11d366e6098d9e24e3cab25cbfd46a8d618fc3925ea86219972ccc63364e578384bb0120a72562312e596894a04ee0518a363
   languageName: node
   linkType: hard
 
@@ -14392,6 +14405,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-gesture-handler@npm:~2.16.1":
+  version: 2.16.2
+  resolution: "react-native-gesture-handler@npm:2.16.2"
+  dependencies:
+    "@egjs/hammerjs": "npm:^2.0.17"
+    hoist-non-react-statics: "npm:^3.3.0"
+    invariant: "npm:^2.2.4"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/227799f5e16f9725d81db524fc06c1fbef226835a5ee989642d132748832f7543ebc750d4309e49bcaa0fb6d1e7dd6b74028785e4b755978ab7f66f05b414c18
+  languageName: node
+  linkType: hard
+
 "react-native-safe-area-context@npm:^4.11.1":
   version: 4.11.1
   resolution: "react-native-safe-area-context@npm:4.11.1"
@@ -14399,6 +14428,32 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/52245f5146061919596b2db7fc808406967b41cc00b85e87eebb87c6a9df7e42f2e1e82936cbb7dd1fe26256192f5ea486c20fc62ae211f8002d2ba2f5b6aa79
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:3.31.1":
+  version: 3.31.1
+  resolution: "react-native-screens@npm:3.31.1"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/54a44fc5a34848195a8e004b9ee2269e8a3560c5fa7922d80eaa1fc6283990d6ef77b3d3ec6004d7df2ad95279d486faf25bb68a82a0e958493891adb7dbac9c
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:^3.31.0":
+  version: 3.35.0
+  resolution: "react-native-screens@npm:3.35.0"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/18085fb68bb2349330cb9b536f79161474788bc478b4b13e23de26d80b68000c60c0b79ba19d430ed0693350c062863f0620da6397d3bd24da08c09181c0fcfd
   languageName: node
   linkType: hard
 
@@ -14415,7 +14470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:^0.74.6":
+"react-native@npm:^0.74.5, react-native@npm:^0.74.6":
   version: 0.74.6
   resolution: "react-native@npm:0.74.6"
   dependencies:


### PR DESCRIPTION
## Description

This PR is intended to start a discussion about **how we could support apps that have enabled React Native's New Architecture** (without upgrading `maplibre-react-native` itself to the New Architecture just yet, which is significantly more work). It includes some quick changes to demonstrate the quirks I found and to render a basic `MapView` example - definitely not a complete solution! 😄 

I was able to render a simple `MapView` without any additional changes on `iOS` (the 'Interop Layer' does all of the work and was updated as of RN 0.74 to be enabled by default). The docs say that "_it will work with every component that has not migrated yet_" (https://github.com/reactwg/react-native-new-architecture/discussions/175), but it does not work in all cases unfortunately, and getting a `MapView` to render on `Android` required additional changes:

1. **Accessing Native Modules** - I'm not clear on the reasons why, but on Android the `MapLibreGL` module and it's methods could not be accessed in the regular way, I had to use the underlying `RCTMLNModule` (not an ideal solution but it works for the purposes of this demo)
2. **Replacing `UIManagerModule`** - [this discussion about the use of `UIManager` in the New Architecture](https://github.com/reactwg/react-native-new-architecture/discussions/201) explains that "_`UIManagerModule` is deprecated in favour of `UIManager` in the New Architecture._". `UIManagerModule` is currently used on `Android` in the `AbstractedEventEmitter` component - replacing it with the new `UIManager` (via `UIManagerHelper`) was required to render a `MapView`

To see the example, run the `expo-app` and from the home screen navigate to **Map**  > **Show Map**.

Feedback and suggestions for next steps are very welcome!

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I formatted JS and TS files with running `yarn lint:eslint:fix` in the root folder
- [ ] I have run tests via `yarn test` in the root folder
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I added/updated a sample (`/packages/examples`)
