### PR TITLE
fix: disable disable-dwarf-with-dsym in plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ PR Title ([#123](link to my pr))
 
 ```
 
+## 10.0.0-alpha.24
+
+feat: support new arch through interop layer ([#483](https://github.com/maplibre/maplibre-react-native/pull/483))
+
 ## 10.0.0-alpha.23
 
 fix: keep @ts-ignore for headingIcon in library ([#477](https://github.com/maplibre/maplibre-react-native/pull/477))

--- a/plugin/src/withMapLibre.ts
+++ b/plugin/src/withMapLibre.ts
@@ -43,7 +43,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin = (c) => {
       await promises.writeFile(
         file,
         applyCocoaPodsModifications(contents),
-        "utf-8",
+        "utf-8"
       );
       return config;
     },
@@ -63,7 +63,7 @@ export function applyCocoaPodsModifications(contents: string): string {
 
 export function addInstallerBlock(
   src: string,
-  blockName: InstallerBlockName,
+  blockName: InstallerBlockName
 ): string {
   const matchBlock = new RegExp(`${blockName}_install do \\|installer\\|`);
   const tag = `${blockName}_installer`;
@@ -96,7 +96,7 @@ export function addInstallerBlock(
 
 export function addMapLibreInstallerBlock(
   src: string,
-  blockName: InstallerBlockName,
+  blockName: InstallerBlockName
 ): string {
   return mergeContents({
     tag: `@maplibre/maplibre-react-native-${blockName}_installer`,
@@ -144,7 +144,7 @@ const withoutSignatures: ConfigPlugin = (config) => {
       {
         shellPath: "/bin/sh",
         shellScript,
-      },
+      }
     );
     return config;
   });
@@ -158,13 +158,16 @@ const withoutSignatures: ConfigPlugin = (config) => {
  *    "artifactPath": "ios/build/*"
  *  }
  */
-const withDwarfDsym: ConfigPlugin = (config) => {
-  return withXcodeProject(config, async (config) => {
-    const xcodeProject = config.modResults;
-    xcodeProject.debugInformationFormat = "dwarf-with-dsym";
-    return config;
-  });
-};
+
+/*  Disabled: dwarf-with-dsym is failing with react-native new architecture */
+
+// const withDwarfDsym: ConfigPlugin = (config) => {
+//   return withXcodeProject(config, async (config) => {
+//     const xcodeProject = config.modResults;
+//     xcodeProject.debugInformationFormat = "dwarf-with-dsym";
+//     return config;
+//   });
+// };
 
 const withExcludedSimulatorArchitectures: ConfigPlugin = (c) => {
   return withXcodeProject(c, (config) => {
@@ -174,9 +177,7 @@ const withExcludedSimulatorArchitectures: ConfigPlugin = (c) => {
 };
 
 const withMapLibre: ConfigPlugin = (config) => {
-  config = withoutSignatures(
-    withDwarfDsym(withExcludedSimulatorArchitectures(config)),
-  );
+  config = withoutSignatures(withExcludedSimulatorArchitectures(config));
   return withCocoaPodsInstallerBlocks(config);
 };
 


### PR DESCRIPTION
## Description

Disable disable-dwarf-with-dsym in config plugin as it causes a build error with react-native new architecture

> CommandError: Malformed xcodebuild results: "UNLOCALIZED_RESOURCES_FOLDER_PATH" variable was not generated in build output. Please report this issue and run your project with Xcode instead.

To-Do:  Re-evaluate with Expo SDK 52

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [X] I formatted JS and TS files with running `yarn lint:eslint:fix` in the root folder
- [X] I have run tests via `yarn test` in the root folder
- [X] I updated the documentation with running `yarn generate` in the root folder
- [X] I mentioned this change in `CHANGELOG.md`
- [ ] I added/updated a sample (`/packages/examples`)
