### PR TITLE
fix: use UIManager exported from react-native

### DIFF
--- a/javascript/utils/index.ts
+++ b/javascript/utils/index.ts
@@ -5,14 +5,11 @@ import {
   findNodeHandle,
   Platform,
   ImageSourcePropType,
+  UIManager,
 } from "react-native";
 
-function getAndroidManagerInstance(module: string): any {
-  const haveViewManagerConfig =
-    NativeModules.UIManager && NativeModules.UIManager.getViewManagerConfig;
-  return haveViewManagerConfig
-    ? NativeModules.UIManager.getViewManagerConfig(module)
-    : NativeModules.UIManager[module];
+function getAndroidManagerInstance(module: string) {
+  return UIManager.getViewManagerConfig(module);
 }
 
 function getIosManagerInstance(module: string): any {
@@ -84,11 +81,13 @@ export function runNativeCommand<ReturnType = NativeArg>(
   }
 
   if (isAndroid()) {
-    return NativeModules.UIManager.dispatchViewManagerCommand(
+    UIManager.dispatchViewManagerCommand(
       handle,
       managerInstance.Commands[name],
       args,
     );
+
+    return null as ReturnType;
   }
 
   return managerInstance[name](handle, ...args);
@@ -125,6 +124,7 @@ export function getIOSModuleName(moduleName: string): string {
   if (moduleName.startsWith("RCT")) {
     return moduleName.substring(3);
   }
+
   return moduleName;
 }
 


### PR DESCRIPTION
Fixes #488

All four examples work with this code applied.

These resources helped me to understand, how this stuff works:

- https://reactnative.dev/docs/0.72/native-components-android
- https://www.nutrient.io/blog/advanced-techniques-for-react-native-ui-components/
