### PR TITLE
chore: remove obsolete `__MAPBOX_STYLESHEET__` check

### DIFF
--- a/ios/MLRN/MLRNStyle.m
+++ b/ios/MLRN/MLRNStyle.m
@@ -24,10 +24,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"fillSortKey"]) {
@@ -88,10 +84,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"lineCap"]) {
@@ -176,10 +168,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"symbolPlacement"]) {
@@ -348,10 +336,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"circleSortKey"]) {
@@ -411,10 +395,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"visibility"]) {
@@ -450,10 +430,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"visibility"]) {
@@ -516,10 +492,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"visibility"]) {
@@ -567,10 +539,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"visibility"]) {
@@ -610,10 +578,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"visibility"]) {
@@ -660,10 +624,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
     if ([prop isEqualToString:@"anchor"]) {

--- a/scripts/templates/MLRNStyle.m.ejs
+++ b/scripts/templates/MLRNStyle.m.ejs
@@ -28,10 +28,6 @@
 
   NSArray<NSString*> *styleProps = [reactStyle allKeys];
   for (NSString *prop in styleProps) {
-    if ([prop isEqualToString:@"__MAPBOX_STYLESHEET__"]) {
-      continue;
-    }
-
     MLRNStyleValue *styleValue = [MLRNStyleValue make:reactStyle[prop]];
 
   <% for (let i = 0; i < layer.properties.length; i++) { -%>


### PR DESCRIPTION
[Another left-over](https://github.com/rnmapbox/maps/commit/e44371675ef98dd50c96f10eded12d3b9fa52a2f#diff-2475e07fe9507927fa8d5231946cdf0604d7c2e920fe2afaa3e96b9862e2addbR126-R128) from a long removed component.