### PR TITLE
chore: cleanup example styles

### DIFF
--- a/packages/examples/src/assets/styles/maplibre-demo-tiles-blue.json
+++ b/packages/examples/src/assets/styles/maplibre-demo-tiles-blue.json
@@ -1,28 +1,28 @@
 {
+  "name": "MapLibre",
   "version": 8,
-  "name": "Basic",
-  "constants": {},
   "sources": {
-    "demotiles": {
-      "type": "vector",
-      "url": "https://demotiles.maplibre.org/tiles/tiles.json"
+    "maplibre": {
+      "url": "https://demotiles.maplibre.org/tiles/tiles.json",
+      "type": "vector"
     }
   },
-  "sprite": "",
-  "glyphs": "",
-  "layers": [{
-    "id": "background",
-    "type": "background",
-    "paint": {
-      "background-color": "#ffffff"
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#ffffff"
+      }
+    },
+    {
+      "id": "countries-fill",
+      "type": "fill",
+      "source": "maplibre",
+      "source-layer": "countries",
+      "paint": {
+        "fill-color": "#285daa"
+      }
     }
-  }, {
-    "id": "land",
-    "type": "fill",
-    "source": "demotiles",
-    "source-layer": "countries",
-    "paint": {
-      "fill-color": "#285daa"
-    }
-  }]
+  ]
 }

--- a/packages/examples/src/assets/styles/maplibre-demo-tiles-white.json
+++ b/packages/examples/src/assets/styles/maplibre-demo-tiles-white.json
@@ -1,28 +1,28 @@
 {
+  "name": "MapLibre",
   "version": 8,
-  "name": "Basic",
-  "constants": {},
   "sources": {
-    "demotiles": {
-      "type": "vector",
-      "url": "https://demotiles.maplibre.org/tiles/tiles.json"
+    "maplibre": {
+      "url": "https://demotiles.maplibre.org/tiles/tiles.json",
+      "type": "vector"
     }
   },
-  "sprite": "",
-  "glyphs": "",
-  "layers": [{
-    "id": "background",
-    "type": "background",
-    "paint": {
-      "background-color": "#285daa"
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#285daa"
+      }
+    },
+    {
+      "id": "countries-fill",
+      "type": "fill",
+      "source": "maplibre",
+      "source-layer": "countries",
+      "paint": {
+        "fill-color": "#ffffff"
+      }
     }
-  }, {
-    "id": "land",
-    "type": "fill",
-    "source": "demotiles",
-    "source-layer": "countries",
-    "paint": {
-      "fill-color": "#ffffff"
-    }
-  }]
+  ]
 }


### PR DESCRIPTION
These two example styles had some minor issues, like the empty `sprite` and `glyph` urls which threw a warning when loading.