### PR TITLE
docs: use lower case primitives

### DIFF
--- a/docs/components/Camera.md
+++ b/docs/components/Camera.md
@@ -56,7 +56,7 @@ Map camera will fly to new coordinate
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
 | `coordinates` | `GeoJSON.Position` | `Yes` | Coordinates that map camera will jump to |
-| `animationDuration` | `Number` | `No` | Duration of camera animation |
+| `animationDuration` | `number` | `No` | Duration of camera animation |
 
 
 
@@ -74,7 +74,7 @@ Map camera will move to new coordinate at the same zoom level
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
 | `coordinates` | `GeoJSON.Position` | `Yes` | Coordinates that map camera will move too |
-| `animationDuration` | `Number` | `No` | Duration of camera animation |
+| `animationDuration` | `number` | `No` | Duration of camera animation |
 
 
 
@@ -92,7 +92,7 @@ Map camera will zoom to specified level
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
 | `zoomLevel` | `number` | `Yes` | Zoom level that the map camera will animate too |
-| `animationDuration` | `Number` | `No` | Duration of camera animation |
+| `animationDuration` | `number` | `No` | Duration of camera animation |
 
 
 

--- a/docs/components/MapView.md
+++ b/docs/components/MapView.md
@@ -117,7 +117,7 @@ Takes snapshot of map with current tiles and returns a URI to the image
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `writeToDisk` | `Boolean` | `No` | If true will create a temp file, otherwise it is in base64 |
+| `writeToDisk` | `boolean` | `No` | If true will create a temp file, otherwise it is in base64 |
 
 
 ### `getZoom()`
@@ -153,7 +153,7 @@ Sets the visibility of all the layers referencing the specified `sourceLayerId` 
 | ---- | :--: | :------: | :----------: |
 | `visible` | `boolean` | `Yes` | Visibility of the layers |
 | `sourceId` | `string` | `Yes` | Identifier of the target source (e.g. 'composite') |
-| `sourceLayerId` | `String` | `No` | Identifier of the target source-layer (e.g. 'building') |
+| `sourceLayerId` | `string` | `No` | Identifier of the target source-layer (e.g. 'building') |
 
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -249,7 +249,7 @@
     "methods": [
       {
         "name": "fitBounds",
-        "docblock": "Map camera transitions to fit provided bounds\n\n@example\ncameraRef.current?.fitBounds([lng, lat], [lng, lat])\ncameraRef.current?.fitBounds([lng, lat], [lng, lat], 20, 1000) // padding for all sides\ncameraRef.current?.fitBounds([lng, lat], [lng, lat], [verticalPadding, horizontalPadding], 1000)\ncameraRef.current?.fitBounds([lng, lat], [lng, lat], [top, right, bottom, left], 1000)\n\n@param {Array<Number>} ne - North east coordinate of bound\n@param {Array<Number>} sw - South west coordinate of bound\n@param {Number|Array<Number>|undefined} padding - Padding for the bounds\n@param {Number=} animationDuration - Duration of camera animation\n@return {void}",
+        "docblock": "Map camera transitions to fit provided bounds\n\n@example\ncameraRef.current?.fitBounds([lng, lat], [lng, lat])\ncameraRef.current?.fitBounds([lng, lat], [lng, lat], 20, 1000) // padding for all sides\ncameraRef.current?.fitBounds([lng, lat], [lng, lat], [verticalPadding, horizontalPadding], 1000)\ncameraRef.current?.fitBounds([lng, lat], [lng, lat], [top, right, bottom, left], 1000)\n\n@param {Array<number>} ne - North east coordinate of bound\n@param {Array<number>} sw - South west coordinate of bound\n@param {number|Array<number>|undefined} padding - Padding for the bounds\n@param {number=} animationDuration - Duration of camera animation\n@return {void}",
         "modifiers": [],
         "params": [
           {
@@ -297,7 +297,7 @@
       },
       {
         "name": "flyTo",
-        "docblock": "Map camera will fly to new coordinate\n\n@example\ncameraRef.current?.flyTo([lng, lat])\ncameraRef.current?.flyTo([lng, lat], 12000)\n\n @param {Array<Number>} coordinates - Coordinates that map camera will jump to\n @param {Number=} animationDuration - Duration of camera animation\n @return {void}",
+        "docblock": "Map camera will fly to new coordinate\n\n@example\ncameraRef.current?.flyTo([lng, lat])\ncameraRef.current?.flyTo([lng, lat], 12000)\n\n @param {Array<number>} coordinates - Coordinates that map camera will jump to\n @param {number=} animationDuration - Duration of camera animation\n @return {void}",
         "modifiers": [],
         "params": [
           {
@@ -312,7 +312,7 @@
             "name": "animationDuration",
             "description": "Duration of camera animation",
             "type": {
-              "name": "Number"
+              "name": "number"
             },
             "optional": true
           }
@@ -329,7 +329,7 @@
       },
       {
         "name": "moveTo",
-        "docblock": "Map camera will move to new coordinate at the same zoom level\n\n@example\ncameraRef.current?.moveTo([lng, lat], 200) // eases camera to new location based on duration\ncameraRef.current?.moveTo([lng, lat]) // snaps camera to new location without any easing\n\n @param {Array<Number>} coordinates - Coordinates that map camera will move too\n @param {Number=} animationDuration - Duration of camera animation\n @return {void}",
+        "docblock": "Map camera will move to new coordinate at the same zoom level\n\n@example\ncameraRef.current?.moveTo([lng, lat], 200) // eases camera to new location based on duration\ncameraRef.current?.moveTo([lng, lat]) // snaps camera to new location without any easing\n\n @param {Array<number>} coordinates - Coordinates that map camera will move too\n @param {number=} animationDuration - Duration of camera animation\n @return {void}",
         "modifiers": [],
         "params": [
           {
@@ -344,7 +344,7 @@
             "name": "animationDuration",
             "description": "Duration of camera animation",
             "type": {
-              "name": "Number"
+              "name": "number"
             },
             "optional": true
           }
@@ -361,7 +361,7 @@
       },
       {
         "name": "zoomTo",
-        "docblock": "Map camera will zoom to specified level\n\n@example\ncameraRef.current?.zoomTo(16)\ncameraRef.current?.zoomTo(16, 100)\n\n@param {Number} zoomLevel - Zoom level that the map camera will animate too\n@param {Number=} animationDuration - Duration of camera animation\n@return {void}",
+        "docblock": "Map camera will zoom to specified level\n\n@example\ncameraRef.current?.zoomTo(16)\ncameraRef.current?.zoomTo(16, 100)\n\n@param {number} zoomLevel - Zoom level that the map camera will animate too\n@param {number=} animationDuration - Duration of camera animation\n@return {void}",
         "modifiers": [],
         "params": [
           {
@@ -376,7 +376,7 @@
             "name": "animationDuration",
             "description": "Duration of camera animation",
             "type": {
-              "name": "Number"
+              "name": "number"
             },
             "optional": true
           }
@@ -2252,7 +2252,7 @@
       },
       {
         "name": "takeSnap",
-        "docblock": "Takes snapshot of map with current tiles and returns a URI to the image\n@param  {Boolean} writeToDisk If true will create a temp file, otherwise it is in base64\n@return {String}",
+        "docblock": "Takes snapshot of map with current tiles and returns a URI to the image\n@param  {boolean} writeToDisk If true will create a temp file, otherwise it is in base64\n@return {string}",
         "modifiers": [
           "async"
         ],
@@ -2261,7 +2261,7 @@
             "name": "writeToDisk",
             "description": "If true will create a temp file, otherwise it is in base64",
             "type": {
-              "name": "Boolean"
+              "name": "boolean"
             },
             "optional": true
           }
@@ -2282,7 +2282,7 @@
       },
       {
         "name": "getZoom",
-        "docblock": "Returns the current zoom of the map view.\n\n@example\nconst zoom = await this._map.getZoom();\n\n@return {Number}",
+        "docblock": "Returns the current zoom of the map view.\n\n@example\nconst zoom = await this._map.getZoom();\n\n@return {number}",
         "modifiers": [
           "async"
         ],
@@ -2305,7 +2305,7 @@
       },
       {
         "name": "getCenter",
-        "docblock": "Returns the map's geographical centerpoint\n\n@example\nconst center = await this._map.getCenter();\n\n@return {Array<Number>} Coordinates",
+        "docblock": "Returns the map's geographical centerpoint\n\n@example\nconst center = await this._map.getCenter();\n\n@return {Array<number>} Coordinates",
         "modifiers": [
           "async"
         ],
@@ -2329,7 +2329,7 @@
       },
       {
         "name": "setSourceVisibility",
-        "docblock": "Sets the visibility of all the layers referencing the specified `sourceLayerId` and/or `sourceId`\n\n@example\nawait this._map.setSourceVisibility(false, 'composite', 'building')\n\n@param {boolean} visible - Visibility of the layers\n@param {String} sourceId - Identifier of the target source (e.g. 'composite')\n@param {String=} sourceLayerId - Identifier of the target source-layer (e.g. 'building')",
+        "docblock": "Sets the visibility of all the layers referencing the specified `sourceLayerId` and/or `sourceId`\n\n@example\nawait this._map.setSourceVisibility(false, 'composite', 'building')\n\n@param {boolean} visible - Visibility of the layers\n@param {string} sourceId - Identifier of the target source (e.g. 'composite')\n@param {string=} sourceLayerId - Identifier of the target source-layer (e.g. 'building')",
         "modifiers": [],
         "params": [
           {
@@ -2352,7 +2352,7 @@
             "name": "sourceLayerId",
             "description": "Identifier of the target source-layer (e.g. 'building')",
             "type": {
-              "name": "String"
+              "name": "string"
             },
             "optional": true
           }
@@ -2707,7 +2707,7 @@
             "name": "name",
             "description": "Name of the offline pack.",
             "type": {
-              "name": "String"
+              "name": "string"
             },
             "optional": false
           }
@@ -2730,7 +2730,7 @@
             "name": "name",
             "description": "Name of the offline pack.",
             "type": {
-              "name": "String"
+              "name": "string"
             },
             "optional": false
           }
@@ -2781,7 +2781,7 @@
             "name": "size",
             "description": "Size of ambient cache.",
             "type": {
-              "name": "Number"
+              "name": "number"
             },
             "optional": false
           }
@@ -2832,7 +2832,7 @@
             "name": "name",
             "description": "Name of the offline pack.",
             "type": {
-              "name": "String"
+              "name": "string"
             },
             "optional": false
           }
@@ -2855,7 +2855,7 @@
             "name": "path",
             "description": "Path to offline tile db on file system.",
             "type": {
-              "name": "String"
+              "name": "string"
             },
             "optional": false
           }
@@ -2878,7 +2878,7 @@
             "name": "limit",
             "description": "Map tile limit count.",
             "type": {
-              "name": "Number"
+              "name": "number"
             },
             "optional": false
           }
@@ -2901,7 +2901,7 @@
             "name": "throttleValue",
             "description": "event throttle value in ms.",
             "type": {
-              "name": "Number"
+              "name": "number"
             },
             "optional": false
           }
@@ -2963,7 +2963,7 @@
             "name": "packName",
             "description": "Name of the offline pack.",
             "type": {
-              "name": "String"
+              "name": "string"
             },
             "optional": false
           }

--- a/docs/guides/Logger.md
+++ b/docs/guides/Logger.md
@@ -10,7 +10,7 @@ Sets the amount of logging.
 
 | Name       |   Type   | Required |                Description                 |
 | ---------- | :------: | :------: | :----------------------------------------: | --------- | ------ | ------- | ---------- |
-| `LogLevel` | `String` |  `Yes`   | required level of logging, can be `"error" | "warning" | "info" | "debug" | "verbose"` |
+| `LogLevel` | `string` |  `Yes`   | required level of logging, can be `"error" | "warning" | "info" | "debug" | "verbose"` |
 
 ### `setLogCallback(LogCallback)`
 

--- a/docs/modules/OfflineManager.md
+++ b/docs/modules/OfflineManager.md
@@ -39,7 +39,7 @@ Invalidates the specified offline pack. This method checks that the tiles in the
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `name` | `String` | `Yes` | Name of the offline pack. |
+| `name` | `string` | `Yes` | Name of the offline pack. |
 
 
 
@@ -55,7 +55,7 @@ Unregisters the given offline pack and allows resources that are no longer requi
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `name` | `String` | `Yes` | Name of the offline pack. |
+| `name` | `string` | `Yes` | Name of the offline pack. |
 
 
 
@@ -95,7 +95,7 @@ Sets the maximum size of the ambient cache in bytes. Disables the ambient cache 
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `size` | `Number` | `Yes` | Size of ambient cache. |
+| `size` | `number` | `Yes` | Size of ambient cache. |
 
 
 
@@ -135,7 +135,7 @@ Retrieves an offline pack that is stored in the database by name.
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `name` | `String` | `Yes` | Name of the offline pack. |
+| `name` | `string` | `Yes` | Name of the offline pack. |
 
 
 
@@ -151,7 +151,7 @@ Sideloads offline db
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `path` | `String` | `Yes` | Path to offline tile db on file system. |
+| `path` | `string` | `Yes` | Path to offline tile db on file system. |
 
 
 
@@ -167,7 +167,7 @@ Sets the maximum number of tiles that may be downloaded and stored on the curren
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `limit` | `Number` | `Yes` | Map tile limit count. |
+| `limit` | `number` | `Yes` | Map tile limit count. |
 
 
 
@@ -183,7 +183,7 @@ Sets the period at which download status events will be sent over the React Nati
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `throttleValue` | `Number` | `Yes` | event throttle value in ms. |
+| `throttleValue` | `number` | `Yes` | event throttle value in ms. |
 
 
 
@@ -219,7 +219,7 @@ Unsubscribes any listeners associated with the offline pack.<br/>It's a good ide
 #### Arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `packName` | `String` | `Yes` | Name of the offline pack. |
+| `packName` | `string` | `Yes` | Name of the offline pack. |
 
 
 

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -399,10 +399,10 @@ export const Camera = memo(
            * cameraRef.current?.fitBounds([lng, lat], [lng, lat], [verticalPadding, horizontalPadding], 1000)
            * cameraRef.current?.fitBounds([lng, lat], [lng, lat], [top, right, bottom, left], 1000)
            *
-           * @param {Array<Number>} ne - North east coordinate of bound
-           * @param {Array<Number>} sw - South west coordinate of bound
-           * @param {Number|Array<Number>|undefined} padding - Padding for the bounds
-           * @param {Number=} animationDuration - Duration of camera animation
+           * @param {Array<number>} ne - North east coordinate of bound
+           * @param {Array<number>} sw - South west coordinate of bound
+           * @param {number|Array<number>|undefined} padding - Padding for the bounds
+           * @param {number=} animationDuration - Duration of camera animation
            * @return {void}
            */
           fitBounds,
@@ -413,8 +413,8 @@ export const Camera = memo(
            * cameraRef.current?.flyTo([lng, lat])
            * cameraRef.current?.flyTo([lng, lat], 12000)
            *
-           *  @param {Array<Number>} coordinates - Coordinates that map camera will jump to
-           *  @param {Number=} animationDuration - Duration of camera animation
+           *  @param {Array<number>} coordinates - Coordinates that map camera will jump to
+           *  @param {number=} animationDuration - Duration of camera animation
            *  @return {void}
            */
           flyTo,
@@ -425,8 +425,8 @@ export const Camera = memo(
            * cameraRef.current?.moveTo([lng, lat], 200) // eases camera to new location based on duration
            * cameraRef.current?.moveTo([lng, lat]) // snaps camera to new location without any easing
            *
-           *  @param {Array<Number>} coordinates - Coordinates that map camera will move too
-           *  @param {Number=} animationDuration - Duration of camera animation
+           *  @param {Array<number>} coordinates - Coordinates that map camera will move too
+           *  @param {number=} animationDuration - Duration of camera animation
            *  @return {void}
            */
           moveTo,
@@ -437,8 +437,8 @@ export const Camera = memo(
            * cameraRef.current?.zoomTo(16)
            * cameraRef.current?.zoomTo(16, 100)
            *
-           * @param {Number} zoomLevel - Zoom level that the map camera will animate too
-           * @param {Number=} animationDuration - Duration of camera animation
+           * @param {number} zoomLevel - Zoom level that the map camera will animate too
+           * @param {number=} animationDuration - Duration of camera animation
            * @return {void}
            */
           zoomTo,

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -355,8 +355,8 @@ export const MapView = memo(
           queryRenderedFeaturesInRect,
           /**
            * Takes snapshot of map with current tiles and returns a URI to the image
-           * @param  {Boolean} writeToDisk If true will create a temp file, otherwise it is in base64
-           * @return {String}
+           * @param  {boolean} writeToDisk If true will create a temp file, otherwise it is in base64
+           * @return {string}
            */
           takeSnap,
           /**
@@ -365,7 +365,7 @@ export const MapView = memo(
            * @example
            * const zoom = await this._map.getZoom();
            *
-           * @return {Number}
+           * @return {number}
            */
           getZoom,
           /**
@@ -374,7 +374,7 @@ export const MapView = memo(
            * @example
            * const center = await this._map.getCenter();
            *
-           * @return {Array<Number>} Coordinates
+           * @return {Array<number>} Coordinates
            */
           getCenter,
           /**
@@ -384,8 +384,8 @@ export const MapView = memo(
            * await this._map.setSourceVisibility(false, 'composite', 'building')
            *
            * @param {boolean} visible - Visibility of the layers
-           * @param {String} sourceId - Identifier of the target source (e.g. 'composite')
-           * @param {String=} sourceLayerId - Identifier of the target source-layer (e.g. 'building')
+           * @param {string} sourceId - Identifier of the target source (e.g. 'composite')
+           * @param {string=} sourceLayerId - Identifier of the target source-layer (e.g. 'building')
            */
           setSourceVisibility,
           /**

--- a/src/modules/offline/OfflineManager.ts
+++ b/src/modules/offline/OfflineManager.ts
@@ -109,7 +109,7 @@ class OfflineManager {
    * @example
    * await OfflineManager.invalidatePack('packName')
    *
-   * @param  {String}  name  Name of the offline pack.
+   * @param  {string}  name  Name of the offline pack.
    * @return {void}
    */
   async invalidatePack(name: string): Promise<void> {
@@ -131,7 +131,7 @@ class OfflineManager {
    * @example
    * await OfflineManager.deletePack('packName')
    *
-   * @param  {String}  name  Name of the offline pack.
+   * @param  {string}  name  Name of the offline pack.
    * @return {void}
    */
   async deletePack(name: string): Promise<void> {
@@ -185,7 +185,7 @@ class OfflineManager {
    * @example
    * await OfflineManager.setMaximumAmbientCacheSize(5000000);
    *
-   * @param  {Number}  size  Size of ambient cache.
+   * @param  {number}  size  Size of ambient cache.
    * @return {void}
    */
   async setMaximumAmbientCacheSize(size: number): Promise<void> {
@@ -228,7 +228,7 @@ class OfflineManager {
    * @example
    * const offlinePack = await OfflineManager.getPack();
    *
-   * @param  {String}  name  Name of the offline pack.
+   * @param  {string}  name  Name of the offline pack.
    * @return {OfflinePack}
    */
   async getPack(name: string) {
@@ -242,7 +242,7 @@ class OfflineManager {
    * @example
    * await OfflineManager.mergeOfflineRegions(path);
    *
-   * @param {String} path Path to offline tile db on file system.
+   * @param {string} path Path to offline tile db on file system.
    * @return {void}
    */
   async mergeOfflineRegions(path: string): Promise<void> {
@@ -257,7 +257,7 @@ class OfflineManager {
    * @example
    * OfflineManager.setTileCountLimit(1000);
    *
-   * @param {Number} limit Map tile limit count.
+   * @param {number} limit Map tile limit count.
    * @return {void}
    */
   setTileCountLimit(limit: number): void {
@@ -271,7 +271,7 @@ class OfflineManager {
    * @example
    * OfflineManager.setProgressEventThrottle(500);
    *
-   * @param {Number} throttleValue event throttle value in ms.
+   * @param {number} throttleValue event throttle value in ms.
    * @return {void}
    */
   setProgressEventThrottle(throttleValue: number): void {
@@ -338,7 +338,7 @@ class OfflineManager {
    * @example
    * OfflineManager.unsubscribe('packName')
    *
-   * @param  {String} packName Name of the offline pack.
+   * @param  {string} packName Name of the offline pack.
    * @return {void}
    */
   unsubscribe(packName: string): void {


### PR DESCRIPTION
Use lower case `string`, `boolean` and `number` types as [recommended by TypeScript](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#the-primitives-string-number-and-boolean).