### PR TITLE
ci: fix audit signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Audit Signatures
-        # `rm -rf docs/node_modules` is necessary due to aliased dependencies breaking signatures
+        # `rm -rf ./docs/node_modules` is necessary due to aliased dependencies breaking signatures
         run: |
-          rm -rf docs/node_modules
+          rm -rf ./docs/node_modules
           npm audit signatures
       - name: Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Audit Signatures
-        run: npm audit signatures
+        # `rm -rf docs/node_modules` is necessary due to aliased dependencies breaking signatures
+        run: |
+          rm -rf docs/node_modules
+          npm audit signatures
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Docusaurus seems to have some package aliased, which in conjunction with yarn workspaces breaks `npm audit signatures`, see this job: https://github.com/maplibre/maplibre-react-native/actions/runs/12715049694/job/35451931426.

By deleting the `docs/node_modules` before `npm audit signatures` it's fixed. You can test locally, with the directory present `npm audit signatures` will fail.