### PR TITLE
ci: increase MAESTRO_DRIVER_STARTUP_TIMEOUT

### DIFF
--- a/.github/workflows/review-ios.yml
+++ b/.github/workflows/review-ios.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           xcrun simctl boot "iPhone 15 Pro"
           xcrun simctl install booted ./ios/MapLibreReactNativeExample.app
-          export MAESTRO_DRIVER_STARTUP_TIMEOUT=60000
+          export MAESTRO_DRIVER_STARTUP_TIMEOUT=240000
           maestro test ./e2e --format junit
 
       - name: Upload Report

--- a/.github/workflows/review-ios.yml
+++ b/.github/workflows/review-ios.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           xcrun simctl boot "iPhone 15 Pro"
           xcrun simctl install booted ./ios/MapLibreReactNativeExample.app
+          export MAESTRO_DRIVER_STARTUP_TIMEOUT=60000
           maestro test ./e2e --format junit
 
       - name: Upload Report


### PR DESCRIPTION
iOS startup is a bit flaky currently: https://github.com/maplibre/maplibre-react-native/actions/runs/12741854668/job/35509351876#step:5:13

Trying to fix it with their recommendation from the docs: https://maestro.mobile.dev/advanced/configuring-maestro-driver-timeout