### PR TITLE
ci: set branch properly for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - $default-branch
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
`$default-branch` is only used for actions templates, doesn't work in a workflow.