### PR TITLE
docs: add search

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -108,6 +108,7 @@ const config: Config = {
         },
       ],
     },
+
     footer: {
       style: "dark",
       links: [
@@ -151,10 +152,17 @@ const config: Config = {
         },
       ],
     },
+
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
       additionalLanguages: ["diff", "ruby"],
+    },
+
+    algolia: {
+      appId: "XPG24MVV4L",
+      apiKey: "88a400aaa583423db0984b785c1de05b",
+      indexName: "maplibre-react-native",
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
The credentials are public and can be committed
- https://docusaurus.io/docs/search#connecting-algolia
- https://support.algolia.com/hc/en-us/articles/18966776061329-Can-the-search-API-key-be-public

To test, just check out this branch and run `yarn docs start` and search should already be working.