### PR TITLE
fix: plugin remove obsolete `gradle.properties`

### DIFF
--- a/src/__tests__/plugin/android/mergeGradleProperties.test.ts
+++ b/src/__tests__/plugin/android/mergeGradleProperties.test.ts
@@ -1,37 +1,43 @@
-import { mergeGradleProperties } from "../../../plugin/android";
+import {
+  GRADLE_PROPERTIES_PREFIX,
+  mergeGradleProperties,
+} from "../../../plugin/android";
 
-const PROPERTY = {
+const OTHER_PROPERTY = {
   type: "property",
-  key: "exampleProperty",
-  value: "value",
+  key: `some.other.exampleProperty`,
+  value: "example",
+} as const;
+
+const OLD_PROPERTY = {
+  type: "property",
+  key: `${GRADLE_PROPERTIES_PREFIX}exampleProperty`,
+  value: "old",
 } as const;
 
 const NEW_PROPERTY = {
   type: "property",
-  key: "newProperty",
+  key: `${GRADLE_PROPERTIES_PREFIX}exampleProperty`,
   value: "new",
 } as const;
 
 describe("Expo Plugin Android – mergeGradleProperties", () => {
-  it("replaces duplicate property", () => {
-    expect(
-      mergeGradleProperties(
-        [
-          PROPERTY,
-          {
-            ...NEW_PROPERTY,
-            value: "old",
-          },
-        ],
-        [NEW_PROPERTY],
-      ),
-    ).toEqual([PROPERTY, NEW_PROPERTY]);
-  });
-
   it("adds new property", () => {
-    expect(mergeGradleProperties([PROPERTY], [NEW_PROPERTY])).toEqual([
-      PROPERTY,
+    expect(mergeGradleProperties([OTHER_PROPERTY], [NEW_PROPERTY])).toEqual([
+      OTHER_PROPERTY,
       NEW_PROPERTY,
     ]);
+  });
+
+  it("removes obsolete property", () => {
+    expect(mergeGradleProperties([OTHER_PROPERTY, OLD_PROPERTY], [])).toEqual([
+      OTHER_PROPERTY,
+    ]);
+  });
+
+  it("replaces property", () => {
+    expect(
+      mergeGradleProperties([OTHER_PROPERTY, OLD_PROPERTY], [NEW_PROPERTY]),
+    ).toEqual([OTHER_PROPERTY, NEW_PROPERTY]);
   });
 });

--- a/src/plugin/android.ts
+++ b/src/plugin/android.ts
@@ -12,6 +12,8 @@ type PropertyItem = {
   value: string;
 };
 
+export const GRADLE_PROPERTIES_PREFIX = "org.maplibre.reactnative.";
+
 export const getGradleProperties = (
   props: MapLibrePluginProps,
 ): PropertyItem[] => {
@@ -20,7 +22,7 @@ export const getGradleProperties = (
       if (key && value) {
         properties.push({
           type: "property",
-          key: `org.maplibre.reactnative.${key}`,
+          key: `${GRADLE_PROPERTIES_PREFIX}${key}`,
           value: value.toString(),
         });
       }
@@ -35,10 +37,13 @@ export const mergeGradleProperties = (
   oldProperties: PropertiesItem[],
   newProperties: PropertyItem[],
 ): PropertiesItem[] => {
-  const newPropertiesKeys = newProperties.map(({ key }) => key);
+  console.log(oldProperties);
   const merged = oldProperties.filter(
     (item) =>
-      !(item.type === "property" && newPropertiesKeys.includes(item.key)),
+      !(
+        item.type === "property" &&
+        item.key.startsWith(GRADLE_PROPERTIES_PREFIX)
+      ),
   );
 
   merged.push(...newProperties);

--- a/src/plugin/android.ts
+++ b/src/plugin/android.ts
@@ -37,7 +37,6 @@ export const mergeGradleProperties = (
   oldProperties: PropertiesItem[],
   newProperties: PropertyItem[],
 ): PropertiesItem[] => {
-  console.log(oldProperties);
   const merged = oldProperties.filter(
     (item) =>
       !(


### PR DESCRIPTION
Previously the Expo plugin would have not remove a property, when removing it from `app.json` or `app.config.{js,ts}`. It only overwrote duplicates. This should not be the case, as it would leave artifacts within the generated `gradle.properties`, making the plugins output for Android non-deterministic. For example the broken behavior previously:

1. Set `locationEngine: "google"` in `app.config.ts`
2. Run `expo prebuild`
  This will add `org.maplibre.reactnative.locationEngine=google` to `gradle.properties`
3. Remove `locationEngine: "google"` in `app.config.ts` again
4. Run `expo prebuild`
  `org.maplibre.reactnative.locationEngine=google` will still be in `gradle.properties`

Now all old properties from MLRN are removed and only the current plugin props are applied.