### PR TITLE
feat: allow configuration of Android SDK variant

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ def getExtOrDefault(name) {
 }
 
 def getConfigurableExtOrDefault(name) {
-    return rootProject.ext.has("org.maplibre.reactnative." + name) ? rootProject.ext.get("org.maplibre.reactnative." + name) : project.properties["org.maplibre.reactnative." + name]
+  return rootProject.ext.has("org.maplibre.reactnative." + name) ? rootProject.ext.get("org.maplibre.reactnative." + name) : project.properties["org.maplibre.reactnative." + name]
 }
 
 def getExtOrIntegerDefault(name) {
@@ -129,7 +129,6 @@ dependencies {
   implementation("org.maplibre.gl:android-plugin-markerview-v9:${getConfigurableExtOrDefault('pluginVersion')}") {
     exclude(group: "org.maplibre.gl", module: "android-sdk")
   }
-
 
   // Dependencies
   implementation "org.maplibre.gl:android-sdk-turf:${getConfigurableExtOrDefault('turfVersion')}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,12 +117,19 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // MapLibre Native
-  implementation "org.maplibre.gl:android-sdk:${getConfigurableExtOrDefault('nativeVersion')}"
+  implementation "org.maplibre.gl:android-sdk-${getConfigurableExtOrDefault('nativeVariant')}:${getConfigurableExtOrDefault('nativeVersion')}"
 
   // MapLibre Plugins
-  implementation "org.maplibre.gl:android-plugin-localization-v9:${getConfigurableExtOrDefault('pluginVersion')}"
-  implementation "org.maplibre.gl:android-plugin-annotation-v9:${getConfigurableExtOrDefault('pluginVersion')}"
-  implementation "org.maplibre.gl:android-plugin-markerview-v9:${getConfigurableExtOrDefault('pluginVersion')}"
+  implementation("org.maplibre.gl:android-plugin-localization-v9:${getConfigurableExtOrDefault('pluginVersion')}") {
+    exclude(group: "org.maplibre.gl", module: "android-sdk")
+  }
+  implementation("org.maplibre.gl:android-plugin-annotation-v9:${getConfigurableExtOrDefault('pluginVersion')}") {
+    exclude(group: "org.maplibre.gl", module: "android-sdk")
+  }
+  implementation("org.maplibre.gl:android-plugin-markerview-v9:${getConfigurableExtOrDefault('pluginVersion')}") {
+    exclude(group: "org.maplibre.gl", module: "android-sdk")
+  }
+
 
   // Dependencies
   implementation "org.maplibre.gl:android-sdk-turf:${getConfigurableExtOrDefault('turfVersion')}"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,6 +6,7 @@ org.maplibre.reactnative.ndkVersion=21.4.7075529
 
 # MapLibre React Native
 org.maplibre.reactnative.nativeVersion=11.8.0
+org.maplibre.reactnative.nativeVariant=opengl
 org.maplibre.reactnative.pluginVersion=3.0.2
 org.maplibre.reactnative.turfVersion=6.0.1
 org.maplibre.reactnative.okhttpVersion=4.9.0

--- a/docs/content/setup/library-customizations.md
+++ b/docs/content/setup/library-customizations.md
@@ -73,7 +73,7 @@ For default values see [`gradle.properties` of the library](https://github.com/m
 
 #### Native Variant
 
-You can choose between the old OpenGL ES and the newer Vulkan rendering backend. Read more on the
+You can choose between the current default OpenGL ES and the newer Vulkan rendering backend. Read more on the
 [MapLibre Native Release introducing Vulkan](https://github.com/maplibre/maplibre-native/releases/tag/android-v11.7.0).
 
 #### Location Engine

--- a/docs/content/setup/library-customizations.md
+++ b/docs/content/setup/library-customizations.md
@@ -37,11 +37,15 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 
 When using React Native, the customizations have to be applied differently for each platform.
 
+### Android
+
 On Android they are set in the `gradle.properties`, each of them prefixed with `org.maplibre.reactnative`. Example:
 
 ```diff
 + org.maplibre.reactnative.nativeVersion=x.x.x
 ```
+
+### iOS
 
 On iOS global variables in the `Podfile` are used, prefixed with `$MLRN`.
 
@@ -55,16 +59,22 @@ target "AppName" do
 
 ### Android
 
-| Prop Key                            | Type                    | Description                                                                                                 |
-| ----------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `nativeVersion`                     | `VersionString`         | Version for [`org.maplibre.gl:android-sdk`](https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk) |
-| `pluginVersion`                     | `VersionString`         | Version for `org.maplibre.gl:android-plugin-*-v9`                                                           |
-| `turfVersion`                       | `VersionString`         | Version for `org.maplibre.gl:android-sdk-turf`                                                              |
-| `okhttpVersion`                     | `VersionString`         | Version for `com.squareup.okhttp3:okhttp`                                                                   |
-| `locationEngine`                    | `"default" \| "google"` | [Location engine to be used](#location-engine)                                                              |
-| `googlePlayServicesLocationVersion` | `VersionString`         | Version for `com.google.android.gms:play-services-location`, only used with `locationEngine: "google"`      |
+| Prop Key                            | Type                    | Description                                                                                                   |
+| ----------------------------------- |-------------------------|---------------------------------------------------------------------------------------------------------------|
+| `nativeVersion`                     | `VersionString`         | Version for [`org.maplibre.gl:android-sdk-*`](https://mvnrepository.com/artifact/org.maplibre.gl/android-sdk) |
+| `nativeVariant`                     | `"opengl" \| "vulkan"`  | [Variant of `org.maplibre.gl:android-sdk-*`](#native-variant)                                                 |
+| `pluginVersion`                     | `VersionString`         | Version for `org.maplibre.gl:android-plugin-*-v9`                                                             |
+| `turfVersion`                       | `VersionString`         | Version for `org.maplibre.gl:android-sdk-turf`                                                                |
+| `okhttpVersion`                     | `VersionString`         | Version for `com.squareup.okhttp3:okhttp`                                                                     |
+| `locationEngine`                    | `"default" \| "google"` | [Location engine to be used](#location-engine)                                                                |
+| `googlePlayServicesLocationVersion` | `VersionString`         | Version for `com.google.android.gms:play-services-location`, only used with `locationEngine: "google"`        |
 
 For default values see [`gradle.properties` of the library](https://github.com/maplibre/maplibre-react-native/tree/main/android/gradle.properties).
+
+#### Native Variant
+
+You can choose between the old OpenGL ES and the newer Vulkan rendering backend. Read more on the
+[MapLibre Native Release introducing Vulkan](https://github.com/maplibre/maplibre-native/releases/tag/android-v11.7.0).
 
 #### Location Engine
 

--- a/src/plugin/MapLibrePluginProps.ts
+++ b/src/plugin/MapLibrePluginProps.ts
@@ -11,9 +11,15 @@ export type MapLibrePluginProps =
        */
       android?: {
         /**
-         * Version for `org.maplibre.gl:android-sdk`
+         * Version for `org.maplibre.gl:android-sdk-*`
          */
         nativeVersion?: VersionString;
+        /**
+         * Variant of `org.maplibre.gl:android-sdk-*`
+         *
+         * @default "vulkan"
+         */
+        nativeVariant?: "opengl" | "vulkan";
         /**
          * Version for `org.maplibre.gl:android-plugin-*-v9`
          */


### PR DESCRIPTION
Fixes #590 

This allows configuration OpenGL ES or Vulkan variant of Android SDK at build time.