### PR TITLE
Export HeadingIndicator from MapLibreRN.ts

### DIFF
--- a/src/MapLibreRN.ts
+++ b/src/MapLibreRN.ts
@@ -38,6 +38,7 @@ export { SymbolLayer } from "./components/SymbolLayer";
 export { RasterLayer } from "./components/RasterLayer";
 export { BackgroundLayer } from "./components/BackgroundLayer";
 export { MarkerView } from "./components/MarkerView";
+export { HeadingIndicator } from "./components/HeadingIndicator";
 
 export {
   LocationManager,


### PR DESCRIPTION
This PR adds an export for HeadingIndicator in MapLibreRN.ts, allowing it to be imported directly from the main package entry point. 