### PR TITLE
fix: fitBounds on iOS across 180th meridian

### DIFF
--- a/ios/MLRN/CameraUpdateItem.m
+++ b/ios/MLRN/CameraUpdateItem.m
@@ -134,16 +134,15 @@
 }
 
 - (BOOL)_areBoundsValid:(MLNCoordinateBounds)bounds {
-  BOOL isValid =
-      CLLocationCoordinate2DIsValid(bounds.ne) && CLLocationCoordinate2DIsValid(bounds.sw);
-
-  if (!isValid) {
-    return NO;
+  if ([self _isLatitudeValid:bounds.ne.latitude] && [self _isLatitudeValid:bounds.sw.latitude]) {
+    return YES;
   }
 
-  CLLocationCoordinate2D ne = bounds.ne;
-  CLLocationCoordinate2D sw = bounds.sw;
-  return [self _isCoordValid:ne] && [self _isCoordValid:sw];
+  return NO;
+}
+
+- (BOOL)_isLatitudeValid:(CLLocationDegrees)latitude {
+  return latitude >= -90 && latitude <= 90;
 }
 
 - (BOOL)_isCoordValid:(CLLocationCoordinate2D)coord {


### PR DESCRIPTION
Fixes #633

For the bounds it's enough to check, if `>= -90 latitude <= 90`. with these changes the following examples works the same on iOS as it already did on Android:

```tsx
import {
  Camera,
  type CameraRef,
  CircleLayer,
  LineLayer,
  MapView,
  ShapeSource,
} from "@maplibre/maplibre-react-native";
import { featureCollection, point } from "@turf/helpers";
import { useRef } from "react";
import { Button } from "react-native";

const AN = point([-149.863129, 61.217381]);
const AN_POSITIVE_BUT_INVALID = point([210.863129, 61.217381]);
const TO = point([139.839478, 35.652832]);

export function BugReport() {
  const cameraRef = useRef<CameraRef>(null);

  return (
    <>
      <Button
        onPress={() => {
          cameraRef.current?.fitBounds(
            AN.geometry.coordinates,
            TO.geometry.coordinates,
            [100, 100, 100, 100],
            0,
          );
        }}
        title="Valid"
      />
      <Button
        onPress={() => {
          cameraRef.current?.fitBounds(
            AN_POSITIVE_BUT_INVALID.geometry.coordinates,
            TO.geometry.coordinates,
            [100, 100, 100, 100],
            0,
          );
        }}
        title="Invalid"
      />

      <MapView style={{ flex: 1 }}>
        <Camera ref={cameraRef} minZoomLevel={0} maxZoomLevel={8} />

        <ShapeSource id="points" shape={featureCollection([AN, TO])}>
          <CircleLayer
            id="circles"
            style={{ circleColor: "red", circleRadius: 20 }}
          />
        </ShapeSource>

        <ShapeSource
          id="180"
          shape={{
            type: "LineString",
            coordinates: [
              [180, -90],
              [180, 90],
            ],
          }}
        >
          <LineLayer id="line" style={{ lineColor: "red", lineWidth: 4 }} />
        </ShapeSource>
      </MapView>
    </>
  );
}
```

Invalid in this case only means for reaching over 180th, it works perfectly fine to fit the bounds to this.