### PR TITLE
Disable setting render mode if map is not fully ready

### DIFF
--- a/android/src/main/java/org/maplibre/reactnative/components/location/MLRNNativeUserLocation.java
+++ b/android/src/main/java/org/maplibre/reactnative/components/location/MLRNNativeUserLocation.java
@@ -60,7 +60,9 @@ public class MLRNNativeUserLocation extends AbstractMapFeature implements OnMapR
 
     public void setRenderMode(@RenderMode.Mode int renderMode) {
         mRenderMode = renderMode;
-        if (mMapView != null) {
+        Style mapStyle = mMap.getStyle();
+        boolean isFullyLoaded = mapStyle != null && mapStyle.isFullyLoaded();
+        if (mMapView != null && isFullyLoaded) {
             LocationComponentManager locationComponent = mMapView.getLocationComponentManager();
             locationComponent.setRenderMode(renderMode);
         }


### PR DESCRIPTION
The `org.maplibre.reactnative.components.location` throws error if the map is not fully ready and we try to set render mode. This fix is only for NativeUserLocation instance, and same fix might be appliable for other cases (`LocationComponentManager.java`)