### PR TITLE
Export additional MapLibre types

### DIFF
--- a/src/MapLibreRN.ts
+++ b/src/MapLibreRN.ts
@@ -82,6 +82,7 @@ export type {
   HillshadeLayerStyle,
   BackgroundLayerStyle,
   LightLayerStyle,
+  Expression
 } from "./types/MapLibreRNStyles";
 
 export type { MapLibrePluginProps } from "./plugin/MapLibrePluginProps";

--- a/src/MapLibreRN.ts
+++ b/src/MapLibreRN.ts
@@ -85,3 +85,5 @@ export type {
 } from "./types/MapLibreRNStyles";
 
 export type { MapLibrePluginProps } from "./plugin/MapLibrePluginProps";
+
+export type { OnPressEvent } from "./types/OnPressEvent";


### PR DESCRIPTION
Adding the Export of some additional types to make it easier to type onPress events and when styling layer components that have more complex style logic. Example usage laid out below.

```tsx
import * as React from 'react';
import {
  FillLayer,
  VectorSource,
  type Expression,
  type FillLayerStyle,
  type OnPressEvent as OnVectorSourcePressEvent,
} from '@maplibre/maplibre-react-native';

const colors = {
  tile_locked: '#4200FF',
  tile_neutral: '#111111',
  tile_in_review: '#CA5310',
  tile_owned: '#34A853',
};

export const VectorLayer = () => {
  const onVectorSourcePress = async (e: OnVectorSourcePressEvent) => {
    console.log(e.point.x, e.point.y);
  };

  const cases = {
    whenIsLocked: ['!', ['has', 'available_data']],
    whenIsOwned(user: string) {
      return [
        'all',
        ['!', ['has', 'available_data']],
        ['==', ['get', 'last_visited'], user],
      ];
    },

    whenIsInReview: ['has', 'reviewing'],
    whenIsInReviewByAddress(address = '') {
      return [
        'all',
        ['has', 'reviewing'],
        ['in', address, ['get', ['literal', 'reviewing']]],
      ];
    },
  };

  const COLOR_CASE: Expression = [
    'case',
    cases.whenIsLocked,
    colors.tile_locked,
    cases.whenIsInReview,
    colors.tile_in_review,
    // Default case
    colors.tile_neutral,
  ];

  const FILL_LAYER_STYLE: FillLayerStyle = {
    fillColor: COLOR_CASE,
    fillAntialias: true,
  };

  return (
    <VectorSource
      id="vectorLayer"
      tileUrlTemplates={['https://maps.io/maps/layers/{z}/{x}/{y}.pbf']}
      onPress={onVectorSourcePress}
    >
      <FillLayer id={'fillLayer'} style={FILL_LAYER_STYLE} />
    </VectorSource>
  );
};
```