### PR TITLE
fix: remove expo plugin withExcludedSimulatorArchitectures

### DIFF
--- a/src/plugin/ios.ts
+++ b/src/plugin/ios.ts
@@ -2,7 +2,6 @@ import {
   type ConfigPlugin,
   withPodfile,
   withXcodeProject,
-  type XcodeProject,
 } from "@expo/config-plugins";
 import {
   mergeContents,
@@ -88,28 +87,6 @@ export const withPodfileGlobalVariables: ConfigPlugin<MapLibrePluginProps> = (
   });
 };
 
-/**
- * Exclude building for arm64 on simulator devices in the pbxproj project.
- * Without this, production builds targeting simulators will fail.
- */
-function setExcludedArchitectures(project: XcodeProject): XcodeProject {
-  const configurations = project.pbxXCBuildConfigurationSection();
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  for (const { name, buildSettings } of Object.values(configurations || {})) {
-    // Guessing that this is the best way to emulate Xcode.
-    // Using `project.addToBuildSettings` modifies too many targets.
-    if (
-      name === "Release" &&
-      typeof buildSettings?.PRODUCT_NAME !== "undefined"
-    ) {
-      buildSettings['"EXCLUDED_ARCHS[sdk=iphonesimulator*]"'] = '"arm64"';
-    }
-  }
-
-  return project;
-}
-
 const withoutSignatures: ConfigPlugin = (config) => {
   return withXcodeProject(config, async (c) => {
     c.modResults.addBuildPhase(
@@ -149,18 +126,9 @@ const withDwarfDsym: ConfigPlugin = (config) => {
   });
 };
 
-const withExcludedSimulatorArchitectures: ConfigPlugin = (config) => {
-  return withXcodeProject(config, (c) => {
-    c.modResults = setExcludedArchitectures(c.modResults);
-
-    return c;
-  });
-};
-
 export const ios = {
   withPodfilePostInstall,
   withPodfileGlobalVariables,
   withoutSignatures,
   withDwarfDsym,
-  withExcludedSimulatorArchitectures,
 };

--- a/src/plugin/withMapLibre.ts
+++ b/src/plugin/withMapLibre.ts
@@ -18,7 +18,6 @@ const withMapLibre: ConfigPlugin<MapLibrePluginProps> = (config, props) => {
   config = android.withGradleProperties(config, props);
 
   // iOS
-  config = ios.withExcludedSimulatorArchitectures(config);
   config = ios.withDwarfDsym(config);
   config = ios.withoutSignatures(config);
   config = ios.withPodfileGlobalVariables(config, props);


### PR DESCRIPTION
This fix only applies to consumers using Expo continuous native code generation. This change also only applies to the iOS project code generated.

Before the PR, the pbxproj file includes this:
<img width="1003" alt="Screenshot 2025-05-27 at 10 25 23 AM" src="https://github.com/user-attachments/assets/b7d87350-8160-4044-921e-c7e66834b1fd" />

After the PR, the pbxproj file does NOT contain the line to exclude arm64 symbols:
<img width="940" alt="Screenshot 2025-05-27 at 10 24 03 AM" src="https://github.com/user-attachments/assets/17b693e3-e5ec-4d86-b59e-4b4e9373d35e" />
