### PR TITLE
feat: upgrade MapLibre Native Android 11.12.1

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,7 +5,7 @@ org.maplibre.reactnative.compileSdkVersion=31
 org.maplibre.reactnative.ndkVersion=21.4.7075529
 
 # MapLibre React Native
-org.maplibre.reactnative.nativeVersion=11.8.1
+org.maplibre.reactnative.nativeVersion=11.12.1
 org.maplibre.reactnative.nativeVariant=opengl
 org.maplibre.reactnative.pluginVersion=3.0.2
 org.maplibre.reactnative.turfVersion=6.0.1

--- a/docs/content/setup/getting-started.md
+++ b/docs/content/setup/getting-started.md
@@ -22,7 +22,7 @@ This package wraps MapLibre Native for Android and iOS, these are the currently 
 <dl>
     <dt>Android</dt>
     <dd>
-      <a href="https://github.com/maplibre/maplibre-native/releases/tag/android-v11.8.1">11.8.1</a>
+      <a href="https://github.com/maplibre/maplibre-native/releases/tag/android-v11.12.1">11.12.1</a>
     </dd>
     <dt>iOS</dt>
     <dd>


### PR DESCRIPTION
Necessary for #924.