### PR TITLE
Fix ios default camera padding

### DIFF
--- a/examples/shared/src/examples/BugReport.tsx
+++ b/examples/shared/src/examples/BugReport.tsx
@@ -1,11 +1,47 @@
-import { MapView } from "@maplibre/maplibre-react-native";
+import {
+  MapView,
+  Camera,
+  ShapeSource,
+  LineLayer,
+} from "@maplibre/maplibre-react-native";
+import { type FeatureCollection } from "geojson";
 
 export function BugReport() {
+  const settings = {
+    bounds: {
+      ne: [17.945307467475175, 55.626240168597775],
+      sw: [17.271308406058154, 49.30274838271916],
+    },
+    padding: {
+      paddingTop: 0,
+      paddingBottom: 400,
+    },
+  };
+
+  const geojson = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          coordinates: [
+            [17.945307467475175, 55.626240168597775],
+            [17.271308406058154, 49.30274838271916],
+          ],
+          type: "LineString",
+        },
+      },
+    ],
+  } as FeatureCollection;
+
   return (
     <MapView style={{ flex: 1 }}>
-      {/*
-         Reproduce your Bug here
-      */}
+      <Camera defaultSettings={settings} />
+
+      <ShapeSource id="geojson" shape={geojson}>
+        <LineLayer id="line" style={{ lineColor: "red", lineWidth: 4 }} />
+      </ShapeSource>
     </MapView>
   );
 }

--- a/examples/shared/src/examples/BugReport.tsx
+++ b/examples/shared/src/examples/BugReport.tsx
@@ -1,47 +1,11 @@
-import {
-  MapView,
-  Camera,
-  ShapeSource,
-  LineLayer,
-} from "@maplibre/maplibre-react-native";
-import { type FeatureCollection } from "geojson";
+import { MapView } from "@maplibre/maplibre-react-native";
 
 export function BugReport() {
-  const settings = {
-    bounds: {
-      ne: [17.945307467475175, 55.626240168597775],
-      sw: [17.271308406058154, 49.30274838271916],
-    },
-    padding: {
-      paddingTop: 0,
-      paddingBottom: 400,
-    },
-  };
-
-  const geojson = {
-    type: "FeatureCollection",
-    features: [
-      {
-        type: "Feature",
-        properties: {},
-        geometry: {
-          coordinates: [
-            [17.945307467475175, 55.626240168597775],
-            [17.271308406058154, 49.30274838271916],
-          ],
-          type: "LineString",
-        },
-      },
-    ],
-  } as FeatureCollection;
-
   return (
     <MapView style={{ flex: 1 }}>
-      <Camera defaultSettings={settings} />
-
-      <ShapeSource id="geojson" shape={geojson}>
-        <LineLayer id="line" style={{ lineColor: "red", lineWidth: 4 }} />
-      </ShapeSource>
+      {/*
+         Reproduce your Bug here
+      */}
     </MapView>
   );
 }

--- a/src/__tests__/components/Camera.test.tsx
+++ b/src/__tests__/components/Camera.test.tsx
@@ -32,7 +32,7 @@ function renderCamera(props: CameraProps = {}) {
 
   const setNativePropsSpy = jest.spyOn(
     mockCameraNativeRef.current,
-    "setNativeProps",
+    "setNativeProps"
   );
 
   function rerender(newProps: CameraProps) {
@@ -316,8 +316,8 @@ describe("Camera", () => {
     });
 
     test("updates when CameraStop changes", () => {
-      const { rerender, setNativePropsSpy } = renderCamera();
-      expect(setNativePropsSpy).toHaveBeenCalledWith({ stop: {} });
+      const { rerender, setNativePropsSpy } = renderCamera({ zoomLevel: 10 });
+      expect(setNativePropsSpy).toHaveBeenCalledWith({ stop: { zoom: 10 } });
 
       rerender({ centerCoordinate: [0, 0] });
 

--- a/src/__tests__/components/Camera.test.tsx
+++ b/src/__tests__/components/Camera.test.tsx
@@ -32,7 +32,7 @@ function renderCamera(props: CameraProps = {}) {
 
   const setNativePropsSpy = jest.spyOn(
     mockCameraNativeRef.current,
-    "setNativeProps"
+    "setNativeProps",
   );
 
   function rerender(newProps: CameraProps) {

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { Platform, requireNativeComponent, type ViewProps } from "react-native";
@@ -540,8 +541,25 @@ export const Camera = memo(
         zoomLevel,
       ]);
 
+      const [nativeDefaultStop] = useState(
+        makeNativeCameraStop(defaultSettings),
+      );
+
+      const isFirstRender = useRef(true);
+
       useEffect(() => {
-        if (nativeStop && Object.keys(nativeStop).length === 0) {
+        const _isFirstRender = isFirstRender.current;
+
+        if (isFirstRender.current) {
+          isFirstRender.current = false;
+        }
+
+        if (
+          _isFirstRender &&
+          nativeDefaultStop &&
+          nativeStop &&
+          Object.keys(nativeStop).length === 0
+        ) {
           return;
         }
 
@@ -550,11 +568,7 @@ export const Camera = memo(
             stop: nativeStop,
           });
         }
-      }, [followUserLocation, nativeStop]);
-
-      const [nativeDefaultStop] = useState(
-        makeNativeCameraStop(defaultSettings),
-      );
+      }, [followUserLocation, nativeStop, nativeDefaultStop]);
 
       return (
         <MLRNCamera

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -541,6 +541,10 @@ export const Camera = memo(
       ]);
 
       useEffect(() => {
+        if (nativeStop && Object.keys(nativeStop).length === 0) {
+          return;
+        }
+
         if (!followUserLocation) {
           nativeCameraRef.current?.setNativeProps({
             stop: nativeStop,


### PR DESCRIPTION
We shouldn't set native `stop` as empty object.

Fixes https://github.com/maplibre/maplibre-react-native/issues/1025