### PR TITLE
fix: MapView contentInset optionals on Android

### DIFF
--- a/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
+++ b/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
@@ -725,10 +725,10 @@ open class MLRNMapView(
     fun setReactContentInset(value: ReadableMap?) {
         if (value != null) {
             val arr = WritableNativeArray()
-            arr.pushDouble(value.getDouble("top"))
-            arr.pushDouble(value.getDouble("right"))
-            arr.pushDouble(value.getDouble("bottom"))
-            arr.pushDouble(value.getDouble("left"))
+            arr.pushDouble(if (value.hasKey("top"))  value.getDouble("top") else 0.0)
+            arr.pushDouble(if (value.hasKey("right"))  value.getDouble("right") else 0.0)
+            arr.pushDouble(if (value.hasKey("bottom"))  value.getDouble("bottom") else 0.0)
+            arr.pushDouble(if (value.hasKey("left"))  value.getDouble("left") else 0.0)
             insets = arr
         } else {
             insets = null

--- a/src/components/map-view/MapView.tsx
+++ b/src/components/map-view/MapView.tsx
@@ -23,7 +23,7 @@ import {
   type ViewProps,
 } from "react-native";
 
-import NativeMapViewComponent, {
+import MapViewNativeComponent, {
   type NativeProps,
 } from "./MapViewNativeComponent";
 import NativeMapViewModule from "./NativeMapViewModule";
@@ -58,7 +58,7 @@ const findNodeHandle = (ref: Component | null) => {
 
   if (!nodeHandle) {
     throw new Error(
-      "NativeMapViewComponent ref is null, wait for the map being initialized",
+      "MapViewNativeComponent ref is null, wait for the map being initialized",
     );
   }
 
@@ -433,7 +433,7 @@ export const MapView = memo(
       const [isReady, setIsReady] = useState(false);
 
       const nativeRef = useRef<
-        Component<ComponentProps<typeof NativeMapViewComponent>> &
+        Component<ComponentProps<typeof MapViewNativeComponent>> &
           Readonly<NativeMethods>
       >(null);
 
@@ -564,7 +564,7 @@ export const MapView = memo(
         if (NativeAndroidTextureMapViewComponent && androidView === "texture") {
           mapView = <NativeAndroidTextureMapViewComponent {...nativeProps} />;
         } else {
-          mapView = <NativeMapViewComponent {...nativeProps} />;
+          mapView = <MapViewNativeComponent {...nativeProps} />;
         }
       }
 


### PR DESCRIPTION
Only iOS supports `WithDefault` in codegen, therefore we have to check if the values are set or fallback.