### PR TITLE
fix: Camera onTrackUserLocationChange null value

### DIFF
--- a/ios/components/camera/MLRNCameraComponentView.mm
+++ b/ios/components/camera/MLRNCameraComponentView.mm
@@ -42,8 +42,12 @@ using namespace facebook::react;
     __typeof__(self) strongSelf = weakSelf;
 
     if (strongSelf != nullptr && strongSelf->_eventEmitter != nullptr) {
+      NSString *trackUserLocation = event[@"trackUserLocation"];
+
       facebook::react::MLRNCameraEventEmitter::OnTrackUserLocationChange eventStruct{
-          [event[@"trackUserLocation"] UTF8String],
+          [trackUserLocation isKindOfClass:[NSString class]]
+              ? folly::dynamic([trackUserLocation UTF8String])
+              : folly::dynamic(nullptr),
       };
       std::dynamic_pointer_cast<const facebook::react::MLRNCameraEventEmitter>(
           strongSelf->_eventEmitter)

--- a/src/components/camera/Camera.tsx
+++ b/src/components/camera/Camera.tsx
@@ -191,7 +191,7 @@ export interface CameraRef {
 export type TrackUserLocation = "default" | "heading" | "course";
 
 export type TrackUserLocationChangeEvent = {
-  trackUserLocation?: TrackUserLocation;
+  trackUserLocation: TrackUserLocation | null;
 };
 
 export type CameraProps = BaseProps &
@@ -299,11 +299,7 @@ export const Camera = memo(
           maxZoom={maxZoom}
           maxBounds={maxBounds}
           trackUserLocation={trackUserLocation}
-          onTrackUserLocationChange={
-            onTrackUserLocationChange as (
-              event: NativeSyntheticEvent<{ trackUserLocation?: string }>,
-            ) => void
-          }
+          onTrackUserLocationChange={onTrackUserLocationChange}
         />
       );
     },

--- a/src/components/camera/CameraNativeComponent.ts
+++ b/src/components/camera/CameraNativeComponent.ts
@@ -5,6 +5,8 @@ import {
   type ViewProps,
 } from "react-native";
 
+import type { UnsafeMixed } from "../../types/codegen/UnsafeMixed";
+
 // START: NativeCameraStop
 type NativeViewPadding = {
   top?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
@@ -36,7 +38,10 @@ type NativeCameraStop = NativeViewState & {
 type NativeTrackUserLocationMode = "none" | "default" | "heading" | "course";
 
 type TrackUserLocationChangeEvent = {
-  trackUserLocation?: string;
+  trackUserLocation: UnsafeMixed<Exclude<
+    NativeTrackUserLocationMode,
+    "none"
+  > | null>;
 };
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
Events can only emit `null`, not `undefined`. To make this work on iOS we have to use `UnsafeMixed`.