### PR TITLE
ci: remove NPM_TOKEN for OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
         run: yarn semantic-release


### PR DESCRIPTION
We [already use OIDC](https://www.npmjs.com/package/@maplibre/maplibre-react-native/v/11.0.0-alpha.20#provenance) publishing, so the token shouldn't be used anymore. https://docs.npmjs.com/trusted-publishers