### PR TITLE
feat: align MapView and Camera APIs with GL JS

### DIFF
--- a/.github/workflows/review-android.yml
+++ b/.github/workflows/review-android.yml
@@ -106,7 +106,6 @@ jobs:
           api-level: 33
           target: google_apis
           arch: x86_64
-          profile: pixel_9_pro
           force-avd-creation: false
           working-directory: ./examples/react-native-app
           script: |

--- a/.github/workflows/review-android.yml
+++ b/.github/workflows/review-android.yml
@@ -110,7 +110,7 @@ jobs:
           working-directory: ./examples/react-native-app
           script: |
             adb install ./android/app-release.apk
-            maestro test ./e2e --format junit
+            maestro test ./e2e/tests/** --format junit
 
       - name: Upload Report
         if: always()

--- a/.github/workflows/review-android.yml
+++ b/.github/workflows/review-android.yml
@@ -106,6 +106,7 @@ jobs:
           api-level: 33
           target: google_apis
           arch: x86_64
+          profile: pixel_9_pro
           force-avd-creation: false
           working-directory: ./examples/react-native-app
           script: |

--- a/.github/workflows/review-ios.yml
+++ b/.github/workflows/review-ios.yml
@@ -83,7 +83,7 @@ jobs:
           xcrun simctl boot "iPhone 16 Pro"
           xcrun simctl install booted ./ios/MapLibreReactNativeExample.app
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
-          maestro test ./e2e --format junit
+          maestro test ./e2e/tests/** --format junit
 
       - name: Upload Report
         if: always()

--- a/android/src/main/java/org/maplibre/reactnative/components/camera/CameraStop.kt
+++ b/android/src/main/java/org/maplibre/reactnative/components/camera/CameraStop.kt
@@ -111,9 +111,8 @@ class CameraStop {
         ): CameraStop {
             val stop = CameraStop()
 
-            if (readableMap.hasKey("longitude") && readableMap.hasKey("latitude")) {
-                stop.center =
-                    LatLng(readableMap.getDouble("latitude"), readableMap.getDouble("longitude"))
+            if (readableMap.hasKey("center")) {
+                stop.center = GeoJSONUtils.toLatLng(readableMap.getArray("center"))
             } else if (readableMap.hasKey("bounds")) {
                 stop.bounds = GeoJSONUtils.toLatLngBounds(readableMap.getArray("bounds"))
             }

--- a/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
+++ b/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
@@ -901,32 +901,36 @@ open class MLRNMapView(
 
     fun queryRenderedFeaturesWithPoint(
         point: PointF, layers: ReadableArray?, filter: Expression?,
-    ): WritableMap {
+    ): WritableArray {
         val features = mapLibreMap!!.queryRenderedFeatures(
             point,
             filter,
             *(layers?.let { Array(layers.size()) { layers.getString(it) } } ?: emptyArray()))
 
 
-        val featureCollection = FeatureCollection.fromFeatures(features)
-        val jsonObject: JsonObject =
-            com.google.gson.JsonParser.parseString(featureCollection.toJson()).asJsonObject
-        return ConvertUtils.toWritableMap(jsonObject)
+        val result = Arguments.createArray()
+        for (feature in features) {
+            val jsonObject = com.google.gson.JsonParser.parseString(feature.toJson()).asJsonObject
+            result.pushMap(ConvertUtils.toWritableMap(jsonObject))
+        }
+        return result
     }
 
 
     fun queryRenderedFeaturesWithRect(
         rect: RectF, layers: ReadableArray?, filter: Expression?,
-    ): WritableMap {
+    ): WritableArray {
         val features = mapLibreMap!!.queryRenderedFeatures(
             rect,
             filter,
             *(layers?.let { Array(layers.size()) { layers.getString(it) } } ?: emptyArray()))
 
-        val featureCollection = FeatureCollection.fromFeatures(features)
-        val jsonObject =
-            com.google.gson.JsonParser.parseString(featureCollection.toJson()).asJsonObject
-        return ConvertUtils.toWritableMap(jsonObject)
+        val result = Arguments.createArray()
+        for (feature in features) {
+            val jsonObject = com.google.gson.JsonParser.parseString(feature.toJson()).asJsonObject
+            result.pushMap(ConvertUtils.toWritableMap(jsonObject))
+        }
+        return result
     }
 
     fun project(mapCoordinate: LatLng): WritableArray {

--- a/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
+++ b/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
@@ -93,7 +93,7 @@ class MLRNMapViewModule(
         withViewportOnUIThread(reactTag, promise) { mapView ->
             promise.resolve(
                 mapView.queryRenderedFeaturesWithPoint(
-                    LatLng(pixelPoint.getDouble(1), pixelPoint.getDouble(0)),
+                    ConvertUtils.toPointF(pixelPoint),
                     layers,
                     ExpressionParser.from(filter),
                 )

--- a/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
+++ b/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
@@ -1,16 +1,15 @@
 package org.maplibre.reactnative.components.mapview
 
+import android.graphics.RectF
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
-import org.maplibre.android.camera.CameraUpdateFactory.newLatLngBounds
 import org.maplibre.android.geometry.LatLng
-import org.maplibre.android.geometry.LatLngBounds
 import org.maplibre.reactnative.NativeMapViewModuleSpec
 import org.maplibre.reactnative.utils.ConvertUtils
 import org.maplibre.reactnative.utils.ExpressionParser
+import org.maplibre.reactnative.utils.GeoJSONUtils
 import org.maplibre.reactnative.utils.ReactTag
 import org.maplibre.reactnative.utils.ReactTagResolver
 
@@ -65,36 +64,36 @@ class MLRNMapViewModule(
     }
 
     override fun project(
-        reactTag: Double, coordinate: ReadableMap, promise: Promise
+        reactTag: Double, lngLat: ReadableArray, promise: Promise
     ) {
         withViewportOnUIThread(reactTag, promise) { mapView ->
             promise.resolve(
                 mapView.project(
-                    LatLng(coordinate.getDouble("latitude"), coordinate.getDouble("longitude"))
+                    GeoJSONUtils.toLatLng(lngLat)!!
                 )
             )
         }
     }
 
     override fun unproject(
-        reactTag: Double, point: ReadableMap, promise: Promise
+        reactTag: Double, pixelPoint: ReadableArray, promise: Promise
     ) {
         withViewportOnUIThread(reactTag, promise) { mapView ->
-            promise.resolve(mapView.unproject(ConvertUtils.toPointF(point)))
+            promise.resolve(mapView.unproject(ConvertUtils.toPointF(pixelPoint)))
         }
     }
 
-    override fun queryRenderedFeaturesWithCoordinate(
+    override fun queryRenderedFeaturesWithPoint(
         reactTag: Double,
-        coordinate: ReadableMap,
+        pixelPoint: ReadableArray,
         layers: ReadableArray?,
         filter: ReadableArray?,
         promise: Promise
     ) {
         withViewportOnUIThread(reactTag, promise) { mapView ->
             promise.resolve(
-                mapView.queryRenderedFeaturesWithCoordinate(
-                    LatLng(coordinate.getDouble("latitude"), coordinate.getDouble("longitude")),
+                mapView.queryRenderedFeaturesWithPoint(
+                    LatLng(pixelPoint.getDouble(1), pixelPoint.getDouble(0)),
                     layers,
                     ExpressionParser.from(filter),
                 )
@@ -104,24 +103,35 @@ class MLRNMapViewModule(
 
     override fun queryRenderedFeaturesWithBounds(
         reactTag: Double,
-        bounds: ReadableArray?,
+        pixelPointBounds: ReadableArray?,
         layers: ReadableArray?,
         filter: ReadableArray?,
         promise: Promise
     ) {
+
+
         withViewportOnUIThread(reactTag, promise) { mapView ->
+            val rect = if (pixelPointBounds == null) {
+                val width = mapView.width.toFloat()
+                val height = mapView.height.toFloat()
+                RectF(0f, 0f, width, height)
+            } else {
+                val topLeft = pixelPointBounds.getArray(0)
+                val bottomRight = pixelPointBounds.getArray(1)
+
+                RectF(
+                    topLeft!!.getDouble(0).toFloat(),
+                    topLeft.getDouble(1).toFloat(),
+                    bottomRight!!.getDouble(0).toFloat(),
+                    bottomRight.getDouble(1).toFloat()
+                )
+            }
+
             promise.resolve(
-                mapView.queryRenderedFeaturesWithBounds(
-                    if (bounds != null && bounds.size() == 4)
-                        LatLngBounds.from(
-                            bounds.getDouble(3),
-                            bounds.getDouble(2),
-                            bounds.getDouble(1),
-                            bounds.getDouble(0)
-                        )
-                    else
-                        LatLngBounds.world(),
-                    layers, ExpressionParser.from(filter),
+                mapView.queryRenderedFeaturesWithRect(
+                    rect,
+                    layers,
+                    ExpressionParser.from(filter),
                 )
             )
         }

--- a/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
+++ b/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
@@ -5,7 +5,6 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.module.annotations.ReactModule
-import org.maplibre.android.geometry.LatLng
 import org.maplibre.reactnative.NativeMapViewModuleSpec
 import org.maplibre.reactnative.utils.ConvertUtils
 import org.maplibre.reactnative.utils.ExpressionParser
@@ -112,9 +111,7 @@ class MLRNMapViewModule(
 
         withViewportOnUIThread(reactTag, promise) { mapView ->
             val rect = if (pixelPointBounds == null) {
-                val width = mapView.width.toFloat()
-                val height = mapView.height.toFloat()
-                RectF(0f, 0f, width, height)
+                null
             } else {
                 val topLeft = pixelPointBounds.getArray(0)
                 val bottomRight = pixelPointBounds.getArray(1)
@@ -145,7 +142,8 @@ class MLRNMapViewModule(
         promise: Promise
     ) {
         withViewportOnUIThread(reactTag, promise) {
-            promise.resolve(it.setSourceVisibility(visible, sourceId, sourceLayerId))
+            it.setSourceVisibility(visible, sourceId, sourceLayerId)
+            promise.resolve(null)
         }
     }
 
@@ -163,7 +161,8 @@ class MLRNMapViewModule(
         reactTag: Double, promise: Promise
     ) {
         withViewportOnUIThread(reactTag, promise) {
-            promise.resolve(it.showAttribution())
+            it.showAttribution()
+            promise.resolve(null)
         }
     }
 }

--- a/android/src/main/java/org/maplibre/reactnative/events/FeatureClickEvent.java
+++ b/android/src/main/java/org/maplibre/reactnative/events/FeatureClickEvent.java
@@ -44,15 +44,12 @@ public class FeatureClickEvent extends AbstractEvent {
         }
         map.putArray("features", features);
 
-        WritableMap coordinates = Arguments.createMap();
-        coordinates.putDouble("latitude", mLatLng.getLatitude());
-        coordinates.putDouble("longitude", mLatLng.getLongitude());
-        map.putMap("coordinates", coordinates);
+        map.putArray("lngLat", GeoJSONUtils.fromLatLng(mLatLng));
 
-        WritableMap point = Arguments.createMap();
-        point.putDouble("x", mPoint.x);
-        point.putDouble("y", mPoint.y);
-        map.putMap("point", point);
+        WritableArray point = Arguments.createArray();
+        point.pushDouble( mPoint.x);
+        point.pushDouble( mPoint.y);
+        map.putArray("point", point);
 
         return map;
     }

--- a/android/src/main/java/org/maplibre/reactnative/utils/ConvertUtils.java
+++ b/android/src/main/java/org/maplibre/reactnative/utils/ConvertUtils.java
@@ -203,8 +203,8 @@ public class ConvertUtils {
         return list;
     }
 
-    public static PointF toPointF(ReadableMap map) {
-        return new PointF((float) map.getDouble("locationX"), (float) map.getDouble("locationY"));
+    public static PointF toPointF(ReadableArray map) {
+        return new PointF((float) map.getDouble(0), (float) map.getDouble(1));
     }
 
     public static RectF toRectF(ReadableArray array) {

--- a/android/src/main/java/org/maplibre/reactnative/utils/GeoJSONUtils.kt
+++ b/android/src/main/java/org/maplibre/reactnative/utils/GeoJSONUtils.kt
@@ -224,12 +224,13 @@ object GeoJSONUtils {
         return geometry
     }
 
+    @JvmStatic
     fun fromLatLng(latLng: LatLng): WritableArray {
-        val coords = doubleArrayOf(latLng.longitude, latLng.latitude)
-        val writableCoords: WritableArray = WritableNativeArray()
-        writableCoords.pushDouble(coords[0])
-        writableCoords.pushDouble(coords[1])
-        return writableCoords
+        val coordinates: WritableArray = WritableNativeArray()
+        coordinates.pushDouble(latLng.longitude)
+        coordinates.pushDouble(latLng.latitude)
+
+        return coordinates
     }
 
     @JvmStatic
@@ -289,10 +290,7 @@ object GeoJSONUtils {
     fun toLatLngBounds(array: ReadableArray?): LatLngBounds? {
         if (array != null && array.size() == 4) {
             return LatLngBounds.from(
-                array.getDouble(3),
-                array.getDouble(2),
-                array.getDouble(1),
-                array.getDouble(0)
+                array.getDouble(3), array.getDouble(2), array.getDouble(1), array.getDouble(0)
             )
         }
 

--- a/docs/content/components/general/camera.md
+++ b/docs/content/components/general/camera.md
@@ -8,14 +8,14 @@ sidebar_label: Camera
 
 ## Props
 
-| Prop                        |                                                                                     Type                                                                                     | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                   |
-| --------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initialViewState`          | `(CameraOptions & {     longitude?: never;     latitude?: never;     bounds?: never;   }) \| (CameraOptions & CameraCenterOptions) \| (CameraOptions & CameraBoundsOptions)` | `none`  | `false`  | Default view settings applied on camera                                                                                                                                                                                                                                                                                                                       |
-| `minZoom`                   |                                                                                   `number`                                                                                   | `none`  | `false`  | Minimum zoom level of the map                                                                                                                                                                                                                                                                                                                                 |
-| `maxZoom`                   |                                                                                   `number`                                                                                   | `none`  | `false`  | Maximum zoom level of the map                                                                                                                                                                                                                                                                                                                                 |
-| `maxBounds`                 |                                                                                   `Bounds`                                                                                   | `none`  | `false`  | Restrict map panning so that the center is within these bounds                                                                                                                                                                                                                                                                                                |
-| `trackUserLocation`         |                                                                     `"default" \| "heading" \| "course"`                                                                     | `none`  | `false`  | The mode used to track the user location on the map:<br/><br/>- undefined: The user's location is not tracked<br/>- "default": Centers the user's location<br/>- "heading": Centers the user's location and uses the compass for bearing<br/>- "course": Centers the user's location and uses the direction of travel for bearing<br/><br/>@default undefined |
-| `onTrackUserLocationChange` |                                                                                    `func`                                                                                    | `none`  | `false`  | Triggered when `trackUserLocation` changes<br/>_signature:_`(event:NativeSyntheticEvent) => void`                                                                                                                                                                                                                                                             |
+| Prop                        |                                                                        Type                                                                         | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initialViewState`          | `(CameraOptions & {     center?: never;     bounds?: never;   }) \| (CameraOptions & CameraCenterOptions) \| (CameraOptions & CameraBoundsOptions)` | `none`  | `false`  | Default view settings applied on camera                                                                                                                                                                                                                                                                                                                       |
+| `minZoom`                   |                                                                      `number`                                                                       | `none`  | `false`  | Minimum zoom level of the map                                                                                                                                                                                                                                                                                                                                 |
+| `maxZoom`                   |                                                                      `number`                                                                       | `none`  | `false`  | Maximum zoom level of the map                                                                                                                                                                                                                                                                                                                                 |
+| `maxBounds`                 |                                                                   `LngLatBounds`                                                                    | `none`  | `false`  | Restrict map panning so that the center is within these bounds                                                                                                                                                                                                                                                                                                |
+| `trackUserLocation`         |                                                        `"default" \| "heading" \| "course"`                                                         | `none`  | `false`  | The mode used to track the user location on the map:<br/><br/>- undefined: The user's location is not tracked<br/>- "default": Centers the user's location<br/>- "heading": Centers the user's location and uses the compass for bearing<br/>- "course": Centers the user's location and uses the direction of travel for bearing<br/><br/>@default undefined |
+| `onTrackUserLocationChange` |                                                                       `func`                                                                        | `none`  | `false`  | Triggered when `trackUserLocation` changes<br/>_signature:_`(event:NativeSyntheticEvent) => void`                                                                                                                                                                                                                                                             |
 
 ## Methods
 
@@ -35,36 +35,36 @@ sidebar_label: Camera
 | ------------------------ | :---: | :------: | ----------- |
 | `{ center, ...options }` | `n/a` |  `Yes`   | undefined   |
 
-### `easeTo({ center, easing = "ease", duration = 500, ...options })`
+### `easeTo({ center, duration = 500, easing = "ease", ...options })`
 
 #### Arguments
 
 | Name                                                      | Type  | Required | Description |
 | --------------------------------------------------------- | :---: | :------: | ----------- |
-| `{ center, easing = "ease", duration = 500, ...options }` | `n/a` |  `Yes`   | undefined   |
+| `{ center, duration = 500, easing = "ease", ...options }` | `n/a` |  `Yes`   | undefined   |
 
-### `flyTo({ center, easing = "fly", duration = 2000, ...options })`
+### `flyTo({ center, duration = 2000, easing = "fly", ...options })`
 
 #### Arguments
 
 | Name                                                      | Type  | Required | Description |
 | --------------------------------------------------------- | :---: | :------: | ----------- |
-| `{ center, easing = "fly", duration = 2000, ...options }` | `n/a` |  `Yes`   | undefined   |
+| `{ center, duration = 2000, easing = "fly", ...options }` | `n/a` |  `Yes`   | undefined   |
 
-### `fitBounds(bounds, [{ easing = "fly", duration = 2000, ...options }])`
+### `fitBounds(bounds, [{ duration = 2000, easing = "fly", ...options }])`
 
 #### Arguments
 
 | Name                                              | Type  | Required | Description |
 | ------------------------------------------------- | :---: | :------: | ----------- |
 | `bounds`                                          | `n/a` |  `Yes`   | undefined   |
-| `{ easing = "fly", duration = 2000, ...options }` | `n/a` |   `No`   | undefined   |
+| `{ duration = 2000, easing = "fly", ...options }` | `n/a` |   `No`   | undefined   |
 
-### `zoomTo(zoom, [{ easing = "ease", duration = 500, ...options }])`
+### `zoomTo(zoom, [{ duration = 500, easing = "ease", ...options }])`
 
 #### Arguments
 
 | Name                                              | Type  | Required | Description |
 | ------------------------------------------------- | :---: | :------: | ----------- |
 | `zoom`                                            | `n/a` |  `Yes`   | undefined   |
-| `{ easing = "ease", duration = 500, ...options }` | `n/a` |   `No`   | undefined   |
+| `{ duration = 500, easing = "ease", ...options }` | `n/a` |   `No`   | undefined   |

--- a/docs/content/components/general/map-view.md
+++ b/docs/content/components/general/map-view.md
@@ -60,13 +60,13 @@ MapLibre Native MapView
 
 ### `getViewState()`
 
-### `project(coordinate)`
+### `project(lngLat)`
 
 #### Arguments
 
-| Name         | Type  | Required | Description |
-| ------------ | :---: | :------: | ----------- |
-| `coordinate` | `n/a` |  `Yes`   | undefined   |
+| Name     | Type  | Required | Description |
+| -------- | :---: | :------: | ----------- |
+| `lngLat` | `n/a` |  `Yes`   | undefined   |
 
 ### `unproject(point)`
 
@@ -76,14 +76,14 @@ MapLibre Native MapView
 | ------- | :---: | :------: | ----------- |
 | `point` | `n/a` |  `Yes`   | undefined   |
 
-### `queryRenderedFeatures([geometryOrOptions], [options])`
+### `queryRenderedFeatures([pixelPointOrPixelPointBoundsOrOptions], [options])`
 
 #### Arguments
 
-| Name                |                                              Type                                              | Required | Description |
-| ------------------- | :--------------------------------------------------------------------------------------------: | :------: | ----------- |
-| `geometryOrOptions` | `\| { longitude: number; latitude: number }<br/>\| Bounds<br/>\| QueryRenderedFeaturesOptions` |   `No`   | undefined   |
-| `options`           |                         `{filter?:FilterExpression;layers?:string[];}`                         |   `No`   | undefined   |
+| Name                                    |                                                                Type                                                                | Required | Description |
+| --------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------: | :------: | ----------- |
+| `pixelPointOrPixelPointBoundsOrOptions` |                            `\| PixelPoint<br/>\| PixelPointBounds<br/>\| QueryRenderedFeaturesOptions`                             |   `No`   | undefined   |
+| `options`                               | `{/***Filterexpressiontofilterthequeriedfeatures*/filter?:FilterExpression;/***IDsoflayerstoqueryfeaturesfrom*/layers?:string[];}` |   `No`   | undefined   |
 
 ### `takeSnap([writeToDisk])`
 

--- a/docs/content/docs.json
+++ b/docs/content/docs.json
@@ -279,7 +279,7 @@
         "modifiers": [],
         "params": [
           {
-            "name": "{ center, easing = \"ease\", duration = 500, ...options }",
+            "name": "{ center, duration = 500, easing = \"ease\", ...options }",
             "optional": false,
             "type": {
               "name": null
@@ -294,7 +294,7 @@
         "modifiers": [],
         "params": [
           {
-            "name": "{ center, easing = \"fly\", duration = 2000, ...options }",
+            "name": "{ center, duration = 2000, easing = \"fly\", ...options }",
             "optional": false,
             "type": {
               "name": null
@@ -316,7 +316,7 @@
             }
           },
           {
-            "name": "{ easing = \"fly\", duration = 2000, ...options }",
+            "name": "{ duration = 2000, easing = \"fly\", ...options }",
             "optional": true,
             "type": {
               "name": null
@@ -338,7 +338,7 @@
             }
           },
           {
-            "name": "{ easing = \"ease\", duration = 500, ...options }",
+            "name": "{ duration = 500, easing = \"ease\", ...options }",
             "optional": true,
             "type": {
               "name": null
@@ -352,7 +352,7 @@
       {
         "name": "initialViewState",
         "required": false,
-        "type": "\\| (CameraOptions & {\n    longitude?: never;\n    latitude?: never;\n    bounds?: never;\n  })\n\\| (CameraOptions & CameraCenterOptions)\n\\| (CameraOptions & CameraBoundsOptions)",
+        "type": "\\| (CameraOptions & {\n    center?: never;\n    bounds?: never;\n  })\n\\| (CameraOptions & CameraCenterOptions)\n\\| (CameraOptions & CameraBoundsOptions)",
         "default": "none",
         "description": "Default view settings applied on camera"
       },
@@ -373,7 +373,7 @@
       {
         "name": "maxBounds",
         "required": false,
-        "type": "Bounds",
+        "type": "LngLatBounds",
         "default": "none",
         "description": "Restrict map panning so that the center is within these bounds"
       },
@@ -1837,7 +1837,7 @@
         "modifiers": [],
         "params": [
           {
-            "name": "coordinate",
+            "name": "lngLat",
             "optional": false,
             "type": {
               "name": null
@@ -1869,17 +1869,17 @@
         ],
         "params": [
           {
-            "name": "geometryOrOptions",
+            "name": "pixelPointOrPixelPointBoundsOrOptions",
             "optional": true,
             "type": {
-              "name": "\\| { longitude: number; latitude: number }\n\\| Bounds\n\\| QueryRenderedFeaturesOptions"
+              "name": "\\| PixelPoint\n\\| PixelPointBounds\n\\| QueryRenderedFeaturesOptions"
             }
           },
           {
             "name": "options",
             "optional": true,
             "type": {
-              "name": "{filter?:FilterExpression;layers?:string[];}"
+              "name": "{/***Filterexpressiontofilterthequeriedfeatures*/filter?:FilterExpression;/***IDsoflayerstoqueryfeaturesfrom*/layers?:string[];}"
             }
           }
         ],

--- a/docs/content/setup/migrations/v11.md
+++ b/docs/content/setup/migrations/v11.md
@@ -58,9 +58,7 @@ Imperative methods have been aligned with the MapLibre GL API as far as possible
 - Renamed methods:
   - `getVisibleBounds()` -> `getBounds()`
   - `getPointInView()` -> `project()`
-    - Params now uses `{ longitude, latitude }` as params
   - `getCoordinateFromView()` -> `unproject()`
-    - Params now uses `{ locationX, locationY }` as params
 - Unified methods:
   - `queryRenderedFeaturesAtPoint()` & `queryRenderedFeaturesInRect()` -> `queryRenderedFeatures()`
     - Now instead of passing pixel coordinates, geographic coordinates are being required to query
@@ -101,7 +99,7 @@ The prop was renamed and the structure was aligned with MapLibre GL and `react-m
 ```diff
 <Camera
 -  centerCoordinate={[longitude, latitude]}
-+  center={{ longitude, latitude }}
++  center={[ longitude, latitude ]}
 -  zoomLevel={10}
 +  zoom={10}
 - heading={15}
@@ -130,7 +128,7 @@ The prop was renamed and the structure was aligned with MapLibre GL and `react-m
 -  defaultSettings={{
 +  initialViewState={{
 -    centerCoordinate: [longitude, latitude],
-+    center: { longitude, latitude },
++    center: [longitude, latitude],
 -    zoomLevel: 10,
 +    zoom: 10,
 -    heading: 15,

--- a/examples/react-native-app/e2e/base-flows/act.yml
+++ b/examples/react-native-app/e2e/base-flows/act.yml
@@ -1,0 +1,4 @@
+appId: org.maplibre.reactnative.example
+---
+- tapOn: "Act"
+

--- a/examples/react-native-app/e2e/base-flows/arrange.yml
+++ b/examples/react-native-app/e2e/base-flows/arrange.yml
@@ -1,11 +1,18 @@
 appId: org.maplibre.reactnative.example
 ---
 - launchApp
+-
 - scrollUntilVisible:
     speed: 80
     element:
       text: "E2E Tests, ›"
 - tapOn: "E2E Tests, ›"
+
+- scrollUntilVisible:
+    speed: 80
+    element:
+      text: "${TEST_NAME}, ›"
 - tapOn: "${TEST_NAME}, ›"
+
 - assertVisible: "${TEST_NAME}"
 - waitForAnimationToEnd

--- a/examples/react-native-app/e2e/base-flows/arrange.yml
+++ b/examples/react-native-app/e2e/base-flows/arrange.yml
@@ -9,9 +9,3 @@ appId: org.maplibre.reactnative.example
 - tapOn: "${TEST_NAME}, ›"
 - assertVisible: "${TEST_NAME}"
 - waitForAnimationToEnd
-
-- tapOn: "Act"
-- assertVisible:
-    id: "assert-result"
-    index: ${ASSERT_INDEX || 0}
-    text: "✅"

--- a/examples/react-native-app/e2e/base-flows/arrange.yml
+++ b/examples/react-native-app/e2e/base-flows/arrange.yml
@@ -1,0 +1,17 @@
+appId: org.maplibre.reactnative.example
+---
+- launchApp
+- scrollUntilVisible:
+    speed: 80
+    element:
+      text: "E2E Tests, ›"
+- tapOn: "E2E Tests, ›"
+- tapOn: "${TEST_NAME}, ›"
+- assertVisible: "${TEST_NAME}"
+- waitForAnimationToEnd
+
+- tapOn: "Act"
+- assertVisible:
+    id: "assert-result"
+    index: ${ASSERT_INDEX || 0}
+    text: "✅"

--- a/examples/react-native-app/e2e/base-flows/arrange.yml
+++ b/examples/react-native-app/e2e/base-flows/arrange.yml
@@ -3,13 +3,11 @@ appId: org.maplibre.reactnative.example
 - launchApp
 
 - scrollUntilVisible:
-    speed: 80
     element:
       text: "E2E Tests, ›"
 - tapOn: "E2E Tests, ›"
 
 - scrollUntilVisible:
-    speed: 80
     element:
       text: "${TEST_NAME}, ›"
 - tapOn: "${TEST_NAME}, ›"

--- a/examples/react-native-app/e2e/base-flows/arrange.yml
+++ b/examples/react-native-app/e2e/base-flows/arrange.yml
@@ -1,7 +1,7 @@
 appId: org.maplibre.reactnative.example
 ---
 - launchApp
--
+
 - scrollUntilVisible:
     speed: 80
     element:

--- a/examples/react-native-app/e2e/base-flows/arrangeActAssert.yml
+++ b/examples/react-native-app/e2e/base-flows/arrangeActAssert.yml
@@ -1,0 +1,7 @@
+appId: org.maplibre.reactnative.example
+---
+- runFlow: ./arrange.yml
+
+- runFlow: ./act.yml
+
+- runFlow: ./assert.yml

--- a/examples/react-native-app/e2e/base-flows/assert.yml
+++ b/examples/react-native-app/e2e/base-flows/assert.yml
@@ -1,0 +1,6 @@
+appId: org.maplibre.reactnative.example
+---
+- assertVisible:
+    id: "assert-result"
+    index: ${ASSERT_INDEX || 0}
+    text: "✅"

--- a/examples/react-native-app/e2e/tests/map-view/getBearing.yml
+++ b/examples/react-native-app/e2e/tests/map-view/getBearing.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: getBearing
+---
+- runFlow: ../../base-flows/arrangeActAssert.yml

--- a/examples/react-native-app/e2e/tests/map-view/getCenter.yml
+++ b/examples/react-native-app/e2e/tests/map-view/getCenter.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: getCenter
+---
+- runFlow: ../../base-flows/arrangeActAssert.yml

--- a/examples/react-native-app/e2e/tests/map-view/getPitch.yml
+++ b/examples/react-native-app/e2e/tests/map-view/getPitch.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: getPitch
+---
+- runFlow: ../../base-flows/arrangeActAssert.yml

--- a/examples/react-native-app/e2e/tests/map-view/getViewState.yml
+++ b/examples/react-native-app/e2e/tests/map-view/getViewState.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: getViewState
+---
+- runFlow: ../../base-flows/arrangeActAssert.yml

--- a/examples/react-native-app/e2e/tests/map-view/getZoom.yml
+++ b/examples/react-native-app/e2e/tests/map-view/getZoom.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: getZoom
+---
+- runFlow: ../../base-flows/assert.yml

--- a/examples/react-native-app/e2e/tests/map-view/project.yml
+++ b/examples/react-native-app/e2e/tests/map-view/project.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: project
+---
+- runFlow: ../../base-flows/arrangeActAssert.yml

--- a/examples/react-native-app/e2e/tests/map-view/queryRenderedFeatures.yml
+++ b/examples/react-native-app/e2e/tests/map-view/queryRenderedFeatures.yml
@@ -1,0 +1,20 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: queryRenderedFeatures
+---
+- runFlow: ../../base-flows/arrange.yml
+
+- runFlow: ../../base-flows/act.yml
+
+- runFlow:
+    file: ../../base-flows/assert.yml
+    env:
+      ASSERT_INDEX: 0
+- runFlow:
+    file: ../../base-flows/assert.yml
+    env:
+      ASSERT_INDEX: 1
+- runFlow:
+    file: ../../base-flows/assert.yml
+    env:
+      ASSERT_INDEX: 2

--- a/examples/react-native-app/e2e/tests/map-view/showAttribution.yml
+++ b/examples/react-native-app/e2e/tests/map-view/showAttribution.yml
@@ -1,9 +1,10 @@
 appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: queryRenderedFeatures
 ---
-- launchApp
-- tapOn: "Map[,]? ›"
-- tapOn: "Show Map[,]? ›"
-- assertVisible: "Show Map"
+- runFlow: ../../base-flows/arrange.yml
+
+- runFlow: ../../base-flows/act.yml
 
 - runFlow:
     when:

--- a/examples/react-native-app/e2e/tests/map-view/showAttribution.yml
+++ b/examples/react-native-app/e2e/tests/map-view/showAttribution.yml
@@ -1,6 +1,6 @@
 appId: org.maplibre.reactnative.example
 env:
-  TEST_NAME: queryRenderedFeatures
+  TEST_NAME: showAttribution
 ---
 - runFlow: ../../base-flows/arrange.yml
 
@@ -10,12 +10,10 @@ env:
     when:
       platform: Android
     commands:
-      - tapOn: "Attribution icon. Activate to show attribution dialog."
       - assertVisible: "MapLibre Android"
 
 - runFlow:
     when:
       platform: iOS
     commands:
-      - tapOn: "About this map"
       - assertVisible: "MapLibre Native iOS"

--- a/examples/react-native-app/e2e/tests/map-view/unproject.yml
+++ b/examples/react-native-app/e2e/tests/map-view/unproject.yml
@@ -1,0 +1,5 @@
+appId: org.maplibre.reactnative.example
+env:
+  TEST_NAME: unproject
+---
+- runFlow: ../../base-flows/arrangeActAssert.yml

--- a/examples/shared/babel.shared.js
+++ b/examples/shared/babel.shared.js
@@ -12,7 +12,10 @@ function withBabelShared(preset) {
   return getBobConfig(
     {
       presets: [preset],
-      plugins: ["react-native-reanimated/plugin"],
+      plugins: [
+        "@babel/plugin-transform-export-namespace-from",
+        "react-native-reanimated/plugin",
+      ],
     },
     { root, pkg },
   );

--- a/examples/shared/package.json
+++ b/examples/shared/package.json
@@ -16,6 +16,7 @@
     "react-native-screens": "*"
   },
   "dependencies": {
+    "@jest/expect-utils": "^29.7.0",
     "@mapbox/geo-viewport": "^0.5.0",
     "@maplibre/maplibre-react-native": "workspace:*",
     "@react-navigation/native": "^7.1.17",
@@ -25,7 +26,9 @@
     "@turf/circle": "^7.1.0",
     "@turf/distance": "^7.1.0",
     "@turf/helpers": "^7.1.0",
-    "moment": "^2.30.1"
+    "jest-diff": "^29.7.0",
+    "moment": "^2.30.1",
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/examples/shared/src/Examples.tsx
+++ b/examples/shared/src/Examples.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from "react-native";
 
+import * as MapLibreE2E from "./examples/e2e/index";
 import * as MapLibreExamples from "./examples/index";
 
 const styles = StyleSheet.create({
@@ -59,6 +60,7 @@ const Examples = new ExampleGroup(
   "MapLibre React Native",
   [
     new ExampleItem("Bug Report", MapLibreExamples.BugReport),
+
     new ExampleGroup("Map", [
       new ExampleItem("Show Map", MapLibreExamples.ShowMap),
       new ExampleItem("Local Style from JSON", MapLibreExamples.LocalStyleJSON),
@@ -88,6 +90,7 @@ const Examples = new ExampleGroup(
       ),
       new ExampleItem("Set Tint Color", MapLibreExamples.SetTintColor),
     ]),
+
     new ExampleGroup("Camera", [
       new ExampleItem(
         "Fit (Bounds, Center/Zoom, Padding)",
@@ -151,6 +154,7 @@ const Examples = new ExampleGroup(
         MapLibreExamples.DataDrivenCircleColors,
       ),
     ]),
+
     new ExampleGroup("Fill/RasterLayer", [
       new ExampleItem("GeoJSON Source", MapLibreExamples.GeoJSONSource),
       new ExampleItem(
@@ -172,9 +176,11 @@ const Examples = new ExampleGroup(
       ),
       new ExampleItem("Image Overlay", MapLibreExamples.ImageOverlay),
     ]),
+
     new ExampleGroup("LineLayer", [
       new ExampleItem("Gradient Line", MapLibreExamples.GradientLine),
     ]),
+
     new ExampleGroup("Sources", [
       new ExampleItem("PMTiles Map Style", MapLibreExamples.PMTilesMapStyle),
       new ExampleItem(
@@ -182,6 +188,7 @@ const Examples = new ExampleGroup(
         MapLibreExamples.PMTilesVectorSource,
       ),
     ]),
+
     new ExampleGroup("Annotations", [
       new ExampleItem(
         "Show Point Annotation",
@@ -195,6 +202,7 @@ const Examples = new ExampleGroup(
       new ExampleItem("Heatmap", MapLibreExamples.Heatmap),
       new ExampleItem("Custom Callout", MapLibreExamples.CustomCallout),
     ]),
+
     new ExampleGroup("Animations", [
       new ExampleItem(
         "Animate Circle along Line",
@@ -205,7 +213,23 @@ const Examples = new ExampleGroup(
       new ExampleItem("Animated Size", MapLibreExamples.AnimatedSize),
       new ExampleItem("Reanimated Point", MapLibreExamples.ReanimatedPoint),
     ]),
+
     new ExampleItem("Cache Management", MapLibreExamples.CacheManagement),
+
+    new ExampleGroup("E2E Tests", [
+      new ExampleItem("getBearing", MapLibreE2E.GetBearing),
+      new ExampleItem("getCenter", MapLibreE2E.GetCenter),
+      new ExampleItem("getPitch", MapLibreE2E.GetPitch),
+      new ExampleItem("getViewState", MapLibreE2E.GetViewState),
+      new ExampleItem("getZoom", MapLibreE2E.GetZoom),
+      new ExampleItem("project", MapLibreE2E.Project),
+      new ExampleItem(
+        "queryRenderedFeatures",
+        MapLibreE2E.QueryRenderedFeatures,
+      ),
+      new ExampleItem("showAttribution", MapLibreE2E.ShowAttribution),
+      new ExampleItem("unproject", MapLibreE2E.Unproject),
+    ]),
   ],
   true,
 );

--- a/examples/shared/src/components/AssertEquals.tsx
+++ b/examples/shared/src/components/AssertEquals.tsx
@@ -1,0 +1,32 @@
+import { equals } from "@jest/expect-utils";
+import { diff } from "jest-diff";
+import { Text } from "react-native";
+
+import { AssertMonospaceText } from "./AssertMonospaceText";
+
+export function AssertEquals<T>({
+  expect,
+  actual,
+}: {
+  expect: T;
+  actual: T | undefined;
+}) {
+  const equalsResult = equals(actual, expect);
+
+  return (
+    <>
+      <Text testID="assert-result">{equalsResult ? "✅" : "❌"}</Text>
+
+      <AssertMonospaceText>
+        {JSON.stringify(actual, null, 2)}
+
+        {!equalsResult && (
+          <>
+            {"\n\n"}
+            {diff(expect, actual)}
+          </>
+        )}
+      </AssertMonospaceText>
+    </>
+  );
+}

--- a/examples/shared/src/components/AssertMonospaceText.tsx
+++ b/examples/shared/src/components/AssertMonospaceText.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import { Platform, StyleSheet, Text } from "react-native";
+
+const styles = StyleSheet.create({
+  root: {
+    padding: 16,
+    width: "100%",
+    textAlign: "left",
+    fontFamily: Platform.select({
+      android: "monospace",
+      ios: "ui-monospace",
+    }),
+  },
+});
+
+type AssertMonospaceTextProps = { children: ReactNode };
+
+export function AssertMonospaceText({ children }: AssertMonospaceTextProps) {
+  return <Text style={styles.root}>{children}</Text>;
+}

--- a/examples/shared/src/components/AssertZod.tsx
+++ b/examples/shared/src/components/AssertZod.tsx
@@ -1,0 +1,33 @@
+import { Text } from "react-native";
+import { z, type ZodType } from "zod";
+
+import { AssertMonospaceText } from "./AssertMonospaceText";
+
+export function AssertZod<T extends ZodType>({
+  schema,
+  actual,
+}: {
+  schema: T;
+  actual: z.infer<T> | undefined;
+}) {
+  const result = schema.safeParse(actual);
+
+  return (
+    <>
+      <Text testID="assert-result">{result.success ? "✅" : "❌"}</Text>
+
+      <AssertMonospaceText>
+        {JSON.stringify(actual, null, 2)}
+
+        {result.error && (
+          <>
+            {"\n\n"}
+            {result.error.issues
+              .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+              .join("\n")}
+          </>
+        )}
+      </AssertMonospaceText>
+    </>
+  );
+}

--- a/examples/shared/src/constants/GEOMETRIES.ts
+++ b/examples/shared/src/constants/GEOMETRIES.ts
@@ -1,14 +1,14 @@
-import type { Bounds } from "../../../../src/types/Bounds";
+import type { LngLat, LngLatBounds } from "@maplibre/maplibre-react-native";
 
-export const EU_BOUNDS: Bounds = [-20, 30, 40, 70];
-export const US_BOUNDS: Bounds = [-140, 20, -60, 60];
+export const EU_BOUNDS: LngLatBounds = [-20, 30, 40, 70];
+export const US_BOUNDS: LngLatBounds = [-140, 20, -60, 60];
 
-export const EU_CENTER_COORDINATES = [
+export const EU_CENTER_COORDINATES: LngLat = [
   (EU_BOUNDS[0] + EU_BOUNDS[2]) / 2,
   (EU_BOUNDS[1] + EU_BOUNDS[3]) / 2,
 ];
 
-export const US_CENTER_COORDINATES = [
+export const US_CENTER_COORDINATES: LngLat = [
   (US_BOUNDS[0] + US_BOUNDS[2]) / 2,
   (US_BOUNDS[1] + US_BOUNDS[3]) / 2,
 ];
@@ -58,6 +58,6 @@ export const ROUTE_FEATURE: GeoJSON.Feature<GeoJSON.LineString> = {
   properties: {},
 };
 
-export const ROUTE_FEATURE_BOUNDS: Bounds = [
+export const ROUTE_FEATURE_BOUNDS: LngLatBounds = [
   -4.553645430300577, 39.38664602683713, 14.364387065834478, 53.546431251184714,
 ];

--- a/examples/shared/src/examples/Annotations/MarkerView.tsx
+++ b/examples/shared/src/examples/Annotations/MarkerView.tsx
@@ -1,5 +1,6 @@
 import {
   Camera,
+  type LngLat,
   MapView,
   MarkerView,
   PointAnnotation,
@@ -44,16 +45,12 @@ function AnnotationContent({ title }: AnnotationContentProps) {
 const COORDINATES = [
   [-73.99155, 40.73581],
   [-73.99155, 40.73681],
-] as [GeoJSON.Position, GeoJSON.Position];
+] as const satisfies [LngLat, LngLat];
 
 function MarkerViewExample() {
   return (
     <MapView>
-      <Camera
-        zoom={16}
-        longitude={COORDINATES[0][0]!}
-        latitude={COORDINATES[0][1]!}
-      />
+      <Camera zoom={16} center={COORDINATES[0]} />
 
       <PointAnnotation coordinate={COORDINATES[1]} id="pt-ann">
         <AnnotationContent title="this is a point annotation" />

--- a/examples/shared/src/examples/Annotations/PointAnnotationAnchors.tsx
+++ b/examples/shared/src/examples/Annotations/PointAnnotationAnchors.tsx
@@ -79,8 +79,7 @@ export function PointAnnotationAnchors() {
     <MapView>
       <Camera
         initialViewState={{
-          longitude: -73.98004319979121,
-          latitude: 40.75272669831773,
+          center: [-73.98004319979121, 40.75272669831773],
           zoom: 17,
         }}
       />

--- a/examples/shared/src/examples/Annotations/ShowPointAnnotation.tsx
+++ b/examples/shared/src/examples/Annotations/ShowPointAnnotation.tsx
@@ -133,7 +133,7 @@ export function ShowPointAnnotation() {
 
           setCoordinates((prevState) => [
             ...prevState,
-            [event.nativeEvent.longitude, event.nativeEvent.latitude],
+            event.nativeEvent.lngLat,
           ]);
         }}
       >
@@ -141,8 +141,7 @@ export function ShowPointAnnotation() {
           initialViewState={
             {
               ...(coordinates[0] && {
-                longitude: coordinates[0][0],
-                latitude: coordinates[0][1],
+                center: coordinates[0],
               }),
               zoom: 16,
             } as InitialViewState

--- a/examples/shared/src/examples/BugReport.tsx
+++ b/examples/shared/src/examples/BugReport.tsx
@@ -2,7 +2,13 @@ import { MapView } from "@maplibre/maplibre-react-native";
 
 export function BugReport() {
   return (
-    <MapView>
+    <MapView
+      onPress={(event) => {
+        event.persist();
+
+        console.log(event.nativeEvent);
+      }}
+    >
       {/*
          Reproduce your Bug here
       */}

--- a/examples/shared/src/examples/Camera/Fit.tsx
+++ b/examples/shared/src/examples/Camera/Fit.tsx
@@ -137,16 +137,14 @@ export function Fit() {
       if (locationType === "usCenter") {
         return {
           ...p,
-          longitude: US_CENTER_COORDINATES[0]!,
-          latitude: US_CENTER_COORDINATES[1]!,
+          center: US_CENTER_COORDINATES[0],
         };
       } else if (locationType === "usBounds") {
         return { ...p, bounds: US_BOUNDS };
       } else if (locationType === "euCenter") {
         return {
           ...p,
-          longitude: EU_CENTER_COORDINATES[0]!,
-          latitude: EU_CENTER_COORDINATES[1]!,
+          center: EU_CENTER_COORDINATES[0],
         };
       } else if (locationType === "euBounds") {
         return { ...p, bounds: EU_BOUNDS };
@@ -236,9 +234,7 @@ export function Fit() {
         <Section
           title={
             "Zoom" +
-            ("bounds" in cameraProps
-              ? " (only used if center coordinate is set)"
-              : "")
+            ("bounds" in cameraProps ? " (only used if center is set)" : "")
           }
           buttons={zoomConfigButtons}
           fade={"bounds" in cameraProps}
@@ -261,10 +257,7 @@ export function Fit() {
               selected: cachedFlyTo === "us",
               onPress: () => {
                 cameraRef.current?.flyTo({
-                  center: {
-                    longitude: US_CENTER_COORDINATES[0]!,
-                    latitude: US_CENTER_COORDINATES[1]!,
-                  },
+                  center: US_CENTER_COORDINATES,
                 });
                 setCachedFlyTo("us");
               },
@@ -274,10 +267,7 @@ export function Fit() {
               selected: cachedFlyTo === "eu",
               onPress: () => {
                 cameraRef.current?.flyTo({
-                  center: {
-                    longitude: EU_CENTER_COORDINATES[0]!,
-                    latitude: EU_CENTER_COORDINATES[1]!,
-                  },
+                  center: EU_CENTER_COORDINATES,
                 });
                 setCachedFlyTo("eu");
               },

--- a/examples/shared/src/examples/Camera/FlyTo.tsx
+++ b/examples/shared/src/examples/Camera/FlyTo.tsx
@@ -1,4 +1,9 @@
-import { Camera, MapView, UserLocation } from "@maplibre/maplibre-react-native";
+import {
+  Camera,
+  type LngLat,
+  MapView,
+  UserLocation,
+} from "@maplibre/maplibre-react-native";
 import { useState } from "react";
 
 import { TabBarView } from "../../components/TabBarView";
@@ -7,7 +12,7 @@ import {
   US_CENTER_COORDINATES,
 } from "../../constants/GEOMETRIES";
 
-const ZERO_ZERO = [0, 0];
+const ZERO_ZERO: LngLat = [0, 0];
 
 const OPTIONS = [
   { label: "0, 0", data: ZERO_ZERO },
@@ -27,13 +32,7 @@ export function FlyTo() {
       }}
     >
       <MapView>
-        <Camera
-          zoom={6}
-          easing="fly"
-          duration={6000}
-          longitude={location[0]}
-          latitude={location[1]}
-        />
+        <Camera zoom={6} easing="fly" duration={6000} center={location} />
         <UserLocation />
       </MapView>
     </TabBarView>

--- a/examples/shared/src/examples/Camera/GetCenter.tsx
+++ b/examples/shared/src/examples/Camera/GetCenter.tsx
@@ -2,7 +2,7 @@ import {
   Camera,
   MapView,
   type MapViewRef,
-  type ViewState,
+  type LngLat,
 } from "@maplibre/maplibre-react-native";
 import { useRef, useState } from "react";
 import { Text } from "react-native";
@@ -11,9 +11,7 @@ import { Bubble } from "../../components/Bubble";
 import { EU_CENTER_COORDINATES } from "../../constants/GEOMETRIES";
 
 export function GetCenter() {
-  const [center, setCenter] = useState<
-    Pick<ViewState, "longitude" | "latitude"> | undefined
-  >();
+  const [center, setCenter] = useState<LngLat | undefined>();
   const mapViewRef = useRef<MapViewRef>(null);
 
   const onRegionDidChange = async () => {
@@ -26,17 +24,13 @@ export function GetCenter() {
   return (
     <>
       <MapView ref={mapViewRef} onRegionDidChange={onRegionDidChange}>
-        <Camera
-          zoom={9}
-          longitude={EU_CENTER_COORDINATES[0]}
-          latitude={EU_CENTER_COORDINATES[1]}
-        />
+        <Camera zoom={9} center={EU_CENTER_COORDINATES} />
       </MapView>
 
       <Bubble>
         <Text>Center</Text>
-        <Text>{center?.longitude ?? "–"}</Text>
-        <Text>{center?.latitude ?? "–"}</Text>
+        <Text>{center?.[0] ?? "–"}</Text>
+        <Text>{center?.[1] ?? "–"}</Text>
       </Bubble>
     </>
   );

--- a/examples/shared/src/examples/Camera/TakeSnapshotWithMap.tsx
+++ b/examples/shared/src/examples/Camera/TakeSnapshotWithMap.tsx
@@ -41,12 +41,7 @@ export function TakeSnapshotWithMap() {
     <>
       <View style={styles.flex1}>
         <MapView ref={mapViewRef} style={styles.map}>
-          <Camera
-            zoom={8}
-            pitch={45}
-            longitude={-122.400021}
-            latitude={37.789085}
-          />
+          <Camera zoom={8} pitch={45} center={[-122.400021, 37.789085]} />
         </MapView>
 
         <View style={styles.imageContainer}>

--- a/examples/shared/src/examples/FillRasterLayer/GeoJSONSource.tsx
+++ b/examples/shared/src/examples/FillRasterLayer/GeoJSONSource.tsx
@@ -13,7 +13,7 @@ import gridPattern from "../../assets/images/maplibre.png";
 export function GeoJSONSource() {
   return (
     <MapView>
-      <Camera zoom={2} longitude={-35.15165038} latitude={40.6235728} />
+      <Camera zoom={2} center={[-35.15165038, 40.6235728]} />
 
       <BackgroundLayer
         id="background"

--- a/examples/shared/src/examples/FillRasterLayer/ImageOverlay.tsx
+++ b/examples/shared/src/examples/FillRasterLayer/ImageOverlay.tsx
@@ -53,7 +53,7 @@ export function ImageOverlay() {
 
   return (
     <MapView>
-      <Camera longitude={-75} latitude={41} zoom={4} />
+      <Camera center={[-75, 41]} zoom={4} />
 
       <ImageSource
         id="image-source"

--- a/examples/shared/src/examples/FillRasterLayer/IndoorBuilding.tsx
+++ b/examples/shared/src/examples/FillRasterLayer/IndoorBuilding.tsx
@@ -42,8 +42,7 @@ export function IndoorBuilding() {
           zoom={16}
           pitch={40}
           bearing={20}
-          longitude={-87.61694}
-          latitude={41.86625}
+          center={[-87.61694, 41.86625]}
         />
 
         <ShapeSource

--- a/examples/shared/src/examples/FillRasterLayer/QueryWithPoint.tsx
+++ b/examples/shared/src/examples/FillRasterLayer/QueryWithPoint.tsx
@@ -37,21 +37,15 @@ export function QueryWithPoint() {
         onPress={async (event) => {
           if (!mapViewRef.current) return;
 
-          const { longitude, latitude } = event.nativeEvent;
+          const features = await mapViewRef.current.queryRenderedFeatures(
+            event.nativeEvent.point,
+            { layers: ["nycFill"] },
+          );
 
-          const featureCollection =
-            await mapViewRef.current.queryRenderedFeatures(
-              {
-                longitude,
-                latitude,
-              },
-              { layers: ["nycFill"] },
-            );
-
-          setSelectedFeature(featureCollection.features[0]);
+          setSelectedFeature(features[0]);
         }}
       >
-        <Camera zoom={9} longitude={-73.970895} latitude={40.723279} />
+        <Camera zoom={9} center={[-73.970895, 40.723279]} />
 
         <ShapeSource
           id="nyc"

--- a/examples/shared/src/examples/LineLayer/GradientLine.tsx
+++ b/examples/shared/src/examples/LineLayer/GradientLine.tsx
@@ -34,9 +34,7 @@ const styles: { lineLayer: any } = {
 export function GradientLine() {
   return (
     <MapView>
-      <Camera
-        initialViewState={{ longitude: -77.035, latitude: 38.875, zoom: 12 }}
-      />
+      <Camera initialViewState={{ center: [-77.035, 38.875], zoom: 12 }} />
 
       <ShapeSource
         id="source1"

--- a/examples/shared/src/examples/MapView/CreateOfflineRegion.tsx
+++ b/examples/shared/src/examples/MapView/CreateOfflineRegion.tsx
@@ -1,6 +1,7 @@
 import geoViewport from "@mapbox/geo-viewport";
 import {
   Camera,
+  type LngLat,
   MapView,
   OfflineManager,
   OfflinePack,
@@ -21,7 +22,7 @@ import {
 import { Bubble } from "../../components/Bubble";
 import { AMERICANA_VECTOR_STYLE } from "../../constants/AMERICANA_VECTOR_STYLE";
 
-const CENTER_COORD: [number, number] = [18.6466, 54.352];
+const CENTER: LngLat = [18.6466, 54.352];
 const MVT_SIZE = 512;
 const PACK_NAME = "test";
 
@@ -94,7 +95,7 @@ export function CreateOfflineRegion() {
   function createPack() {
     const { width, height } = Dimensions.get("window");
     const viewportBounds = geoViewport.bounds(
-      CENTER_COORD,
+      CENTER,
       12,
       [width, height],
       MVT_SIZE,
@@ -184,8 +185,7 @@ export function CreateOfflineRegion() {
       >
         <Camera
           initialViewState={{
-            longitude: CENTER_COORD[0],
-            latitude: CENTER_COORD[1],
+            center: CENTER,
             zoom: 11,
           }}
         />

--- a/examples/shared/src/examples/MapView/ProjectUnproject.tsx
+++ b/examples/shared/src/examples/MapView/ProjectUnproject.tsx
@@ -1,7 +1,9 @@
 import {
   Camera,
+  type LngLat,
   MapView,
   type MapViewRef,
+  type PixelPoint,
 } from "@maplibre/maplibre-react-native";
 import { useRef, useState } from "react";
 import { Text } from "react-native";
@@ -15,14 +17,8 @@ const styles = {
 export function ProjectUnproject() {
   const mapViewRef = useRef<MapViewRef>(null);
 
-  const [coordinates, setCoordinates] = useState<{
-    longitude: number;
-    latitude: number;
-  }>();
-  const [point, setPoint] = useState<{
-    locationX: number;
-    locationY: number;
-  }>();
+  const [coordinates, setCoordinates] = useState<LngLat>();
+  const [point, setPoint] = useState<PixelPoint>();
 
   return (
     <>
@@ -30,25 +26,17 @@ export function ProjectUnproject() {
         ref={mapViewRef}
         onPress={async (event) => {
           /*
-           * The event actually contains both coordinate and point info,
+           * The event actually contains both coordinates and pixel point,
            * project/unproject is only used for demonstration
            */
 
           event.persist();
 
           setCoordinates(
-            await mapViewRef.current?.unproject({
-              locationX: event.nativeEvent.locationX,
-              locationY: event.nativeEvent.locationY,
-            }),
+            await mapViewRef.current?.unproject(event.nativeEvent.point),
           );
 
-          setPoint(
-            await mapViewRef.current?.project({
-              longitude: event.nativeEvent.longitude,
-              latitude: event.nativeEvent.latitude,
-            }),
-          );
+          setPoint(await mapViewRef.current?.project(event.nativeEvent.lngLat));
         }}
         style={styles.mapView}
       >
@@ -58,13 +46,13 @@ export function ProjectUnproject() {
       <Bubble>
         {coordinates && point ? (
           <>
-            <Text>Longitude: {coordinates.longitude}</Text>
-            <Text>Latitude: {coordinates.latitude}</Text>
-            <Text>X: {point.locationX}</Text>
-            <Text>Y: {point.locationY}</Text>
+            <Text>Longitude: {coordinates[0]}</Text>
+            <Text>Latitude: {coordinates[1]}</Text>
+            <Text>X: {point[0]}</Text>
+            <Text>Y: {point[1]}</Text>
           </>
         ) : (
-          <Text>Touch map to see xy pixel location</Text>
+          <Text>Touch map to see pixel point</Text>
         )}
       </Bubble>
     </>

--- a/examples/shared/src/examples/MapView/ShowClick.tsx
+++ b/examples/shared/src/examples/MapView/ShowClick.tsx
@@ -20,10 +20,10 @@ export function ShowClick() {
         </Bubble>
       ) : (
         <Bubble>
-          <Text>Longitude: {pressEvent.longitude}</Text>
-          <Text>Latitude: {pressEvent.latitude}</Text>
-          <Text>Screen Point X: {pressEvent.locationX}</Text>
-          <Text>Screen Point Y: {pressEvent.locationY}</Text>
+          <Text>Longitude: {pressEvent.lngLat[0]}</Text>
+          <Text>Latitude: {pressEvent.lngLat[1]}</Text>
+          <Text>Screen Point X: {pressEvent.point[0]}</Text>
+          <Text>Screen Point Y: {pressEvent.point[1]}</Text>
         </Bubble>
       )}
     </>

--- a/examples/shared/src/examples/MapView/ShowRegionDidChange.tsx
+++ b/examples/shared/src/examples/MapView/ShowRegionDidChange.tsx
@@ -54,14 +54,14 @@ export function ShowRegionDidChange() {
 
       <Bubble style={styles.bubble}>
         {!viewStateChangeEvent ||
-        viewStateChangeEvent.longitude === 0 ||
-        viewStateChangeEvent.latitude === 0 ? (
+        (viewStateChangeEvent.center[0] === 0 &&
+          viewStateChangeEvent.center[1] === 0) ? (
           <Text>Move the map!</Text>
         ) : (
           <>
             <Text>{reason}</Text>
-            <Text>Longitude: {viewStateChangeEvent.longitude}</Text>
-            <Text>Latitude: {viewStateChangeEvent.latitude}</Text>
+            <Text>Longitude: {viewStateChangeEvent.center[0]}</Text>
+            <Text>Latitude: {viewStateChangeEvent.center[1]}</Text>
             <Text>Visible Bounds: {viewStateChangeEvent.bounds}</Text>
             <Text>Zoom Level: {viewStateChangeEvent.zoom}</Text>
             <Text>Heading: {viewStateChangeEvent.bearing}</Text>

--- a/examples/shared/src/examples/SymbolCircleLayer/CustomIcon.tsx
+++ b/examples/shared/src/examples/SymbolCircleLayer/CustomIcon.tsx
@@ -28,10 +28,7 @@ export function CustomIcon() {
         onPress={async (event) => {
           const point: GeoJSON.Point = {
             type: "Point",
-            coordinates: [
-              event.nativeEvent.longitude,
-              event.nativeEvent.latitude,
-            ],
+            coordinates: event.nativeEvent.lngLat,
           };
 
           setGeometries((prev) => [...prev, point]);
@@ -42,16 +39,10 @@ export function CustomIcon() {
           hitbox={{ width: 20, height: 20 }}
           onPress={(event) => {
             console.log(
-              "You pressed a layer here are your features:",
+              "Layer pressed, queried features:",
               event.nativeEvent.features,
-              {
-                longitude: event.nativeEvent.longitude,
-                latitude: event.nativeEvent.latitude,
-              },
-              {
-                locationX: event.nativeEvent.locationX,
-                locationY: event.nativeEvent.locationY,
-              },
+              event.nativeEvent.lngLat,
+              event.nativeEvent.point,
             );
           }}
           shape={{ type: "GeometryCollection", geometries }}

--- a/examples/shared/src/examples/SymbolCircleLayer/DataDrivenCircleColors.tsx
+++ b/examples/shared/src/examples/SymbolCircleLayer/DataDrivenCircleColors.tsx
@@ -36,12 +36,7 @@ const styles: { circles: any } = {
 export function DataDrivenCircleColors() {
   return (
     <MapView>
-      <Camera
-        zoom={10}
-        pitch={45}
-        longitude={-122.400021}
-        latitude={37.789085}
-      />
+      <Camera zoom={10} pitch={45} center={[-122.400021, 37.789085]} />
 
       <VectorSource id="population" url="mapbox://examples.8fgz4egr">
         <CircleLayer

--- a/examples/shared/src/examples/UserLocation/FollowUserLocationRenderMode.tsx
+++ b/examples/shared/src/examples/UserLocation/FollowUserLocationRenderMode.tsx
@@ -85,7 +85,7 @@ export function FollowUserLocationRenderMode() {
         <Camera
           trackUserLocation={trackUserLocation}
           zoom={14}
-          initialViewState={{ longitude: 10, latitude: 50, zoom: 2 }}
+          initialViewState={{ center: [10, 50], zoom: 2 }}
           onTrackUserLocationChange={(event) => {
             console.log(JSON.stringify(event.nativeEvent));
 

--- a/examples/shared/src/examples/e2e/index.ts
+++ b/examples/shared/src/examples/e2e/index.ts
@@ -1,0 +1,9 @@
+export { GetBearing } from "./map-view/GetBearing";
+export { GetCenter } from "./map-view/GetCenter";
+export { GetPitch } from "./map-view/GetPitch";
+export { GetViewState } from "./map-view/GetViewState";
+export { GetZoom } from "./map-view/GetZoom";
+export { Project } from "./map-view/Project";
+export { QueryRenderedFeatures } from "./map-view/QueryRenderedFeatures";
+export { ShowAttribution } from "./map-view/ShowAttribution";
+export { Unproject } from "./map-view/Unproject";

--- a/examples/shared/src/examples/e2e/map-view/GetBearing.tsx
+++ b/examples/shared/src/examples/e2e/map-view/GetBearing.tsx
@@ -1,0 +1,27 @@
+import { MapView, type MapViewRef } from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+
+import { AssertEquals } from "../../../components/AssertEquals";
+import { Bubble } from "../../../components/Bubble";
+
+export function GetBearing() {
+  const mapViewRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<number>();
+
+  return (
+    <>
+      <MapView ref={mapViewRef} testID="map-view" />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapViewRef.current?.getBearing());
+          }}
+        />
+
+        <AssertEquals expect={0} actual={result} />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/GetCenter.tsx
+++ b/examples/shared/src/examples/e2e/map-view/GetCenter.tsx
@@ -1,0 +1,38 @@
+import {
+  type LngLat,
+  MapView,
+  type MapViewRef,
+} from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+import { z } from "zod";
+
+import { AssertZod } from "../../../components/AssertZod";
+import { Bubble } from "../../../components/Bubble";
+
+export function GetCenter() {
+  const mapViewRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<LngLat>();
+
+  return (
+    <>
+      <MapView ref={mapViewRef} testID="map-view" />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapViewRef.current?.getCenter());
+          }}
+        />
+
+        <AssertZod
+          schema={z.tuple([
+            z.number().min(-0.1).max(0.1),
+            z.number().min(-0.1).max(0.1),
+          ])}
+          actual={result}
+        />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/GetPitch.tsx
+++ b/examples/shared/src/examples/e2e/map-view/GetPitch.tsx
@@ -1,0 +1,27 @@
+import { MapView, type MapViewRef } from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+
+import { AssertEquals } from "../../../components/AssertEquals";
+import { Bubble } from "../../../components/Bubble";
+
+export function GetPitch() {
+  const mapViewRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<number>();
+
+  return (
+    <>
+      <MapView ref={mapViewRef} testID="map-view" />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapViewRef.current?.getPitch());
+          }}
+        />
+
+        <AssertEquals expect={0} actual={result} />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/GetViewState.tsx
+++ b/examples/shared/src/examples/e2e/map-view/GetViewState.tsx
@@ -1,0 +1,41 @@
+import {
+  MapView,
+  type MapViewRef,
+  type ViewState,
+} from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+import * as z from "zod";
+
+import { AssertZod } from "../../../components/AssertZod";
+import { Bubble } from "../../../components/Bubble";
+
+export function GetViewState() {
+  const mapRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<ViewState>();
+
+  return (
+    <>
+      <MapView ref={mapRef} />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapRef.current?.getViewState());
+          }}
+        />
+
+        <AssertZod
+          schema={z.object({
+            center: z.tuple([z.number(), z.number()]),
+            zoom: z.number(),
+            bearing: z.number().refine((value) => value === 0),
+            pitch: z.number().refine((value) => value === 0),
+            bounds: z.tuple([z.number(), z.number(), z.number(), z.number()]),
+          })}
+          actual={result}
+        />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/GetZoom.tsx
+++ b/examples/shared/src/examples/e2e/map-view/GetZoom.tsx
@@ -1,0 +1,28 @@
+import { MapView, type MapViewRef } from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+import { z } from "zod";
+
+import { AssertZod } from "../../../components/AssertZod";
+import { Bubble } from "../../../components/Bubble";
+
+export function GetZoom() {
+  const mapRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<number>();
+
+  return (
+    <>
+      <MapView ref={mapRef} />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapRef.current?.getZoom());
+          }}
+        />
+
+        <AssertZod schema={z.number().min(0).max(1)} actual={result} />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/Project.tsx
+++ b/examples/shared/src/examples/e2e/map-view/Project.tsx
@@ -1,0 +1,38 @@
+import {
+  MapView,
+  type MapViewRef,
+  type PixelPoint,
+} from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+import { z } from "zod";
+
+import { AssertZod } from "../../../components/AssertZod";
+import { Bubble } from "../../../components/Bubble";
+
+export function Project() {
+  const mapRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<PixelPoint>();
+
+  return (
+    <>
+      <MapView ref={mapRef} />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapRef.current?.project([0, 0]));
+          }}
+        />
+
+        <AssertZod
+          schema={z.tuple([
+            z.number().min(180).max(500),
+            z.number().min(180).max(500),
+          ])}
+          actual={result}
+        />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/Project.tsx
+++ b/examples/shared/src/examples/e2e/map-view/Project.tsx
@@ -4,18 +4,26 @@ import {
   type PixelPoint,
 } from "@maplibre/maplibre-react-native";
 import { useRef, useState } from "react";
-import { Button } from "react-native";
+import { Button, type LayoutRectangle, StyleSheet, View } from "react-native";
 import { z } from "zod";
 
 import { AssertZod } from "../../../components/AssertZod";
 import { Bubble } from "../../../components/Bubble";
 
+const styles = StyleSheet.create({
+  flex1: { flex: 1 },
+});
+
 export function Project() {
   const mapRef = useRef<MapViewRef>(null);
   const [result, setResult] = useState<PixelPoint>();
+  const [layout, setLayout] = useState<LayoutRectangle>();
 
   return (
-    <>
+    <View
+      style={styles.flex1}
+      onLayout={(event) => setLayout(event.nativeEvent.layout)}
+    >
       <MapView ref={mapRef} />
       <Bubble>
         <Button
@@ -27,12 +35,18 @@ export function Project() {
 
         <AssertZod
           schema={z.tuple([
-            z.number().min(180).max(500),
-            z.number().min(180).max(500),
+            z
+              .number()
+              .min((layout?.width ?? 0) / 2 - 1)
+              .max((layout?.width ?? 0) / 2 + 1),
+            z
+              .number()
+              .min((layout?.height ?? 0) / 2 - 1)
+              .max((layout?.height ?? 0) / 2 + 1),
           ])}
           actual={result}
         />
       </Bubble>
-    </>
+    </View>
   );
 }

--- a/examples/shared/src/examples/e2e/map-view/QueryRenderedFeatures.tsx
+++ b/examples/shared/src/examples/e2e/map-view/QueryRenderedFeatures.tsx
@@ -1,0 +1,116 @@
+import {
+  CircleLayer,
+  MapView,
+  type MapViewRef,
+  ShapeSource,
+} from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button, type LayoutRectangle, Platform, View } from "react-native";
+
+import { AssertEquals } from "../../../components/AssertEquals";
+import { Bubble } from "../../../components/Bubble";
+import { colors } from "../../../styles/colors";
+
+const FEATURE: GeoJSON.Feature = {
+  type: "Feature",
+  properties: { type: "landmark" },
+  geometry: { type: "Point", coordinates: [0, 0] },
+};
+
+const FEATURES: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: { type: "restaurant" },
+      geometry: { type: "Point", coordinates: [-8, -8] },
+    },
+    FEATURE,
+    {
+      type: "Feature",
+      properties: { type: "shop" },
+      geometry: { type: "Point", coordinates: [8, 8] },
+    },
+  ],
+};
+
+export function QueryRenderedFeatures() {
+  const mapViewRef = useRef<MapViewRef>(null);
+  const [layout, setLayout] = useState<LayoutRectangle>();
+  const [featuresPoint, setFeaturesPoint] = useState<GeoJSON.Feature[]>();
+  const [featuresBounds, setFeaturesBounds] = useState<GeoJSON.Feature[]>();
+  const [featuresViewport, setFeaturesViewport] = useState<GeoJSON.Feature[]>();
+
+  console.log(featuresViewport);
+
+  return (
+    <View
+      style={{ flex: 1 }}
+      onLayout={(event) => {
+        setLayout(event.nativeEvent.layout);
+      }}
+    >
+      <MapView ref={mapViewRef}>
+        <ShapeSource id="source" shape={FEATURES}>
+          <CircleLayer
+            id="circles"
+            style={{
+              circleRadius: 10,
+              circleColor: colors.blue,
+            }}
+          />
+        </ShapeSource>
+      </MapView>
+
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            if (!layout) {
+              return;
+            }
+
+            setFeaturesPoint(
+              await mapViewRef.current?.queryRenderedFeatures(
+                [layout.width / 2, layout.height / 2],
+                { layers: ["circles"] },
+              ),
+            );
+
+            setFeaturesBounds(
+              await mapViewRef.current?.queryRenderedFeatures(
+                [
+                  [layout.width / 2 - 100, layout.height / 2 - 100],
+                  [layout.width / 2 + 100, layout.height / 2 + 100],
+                ],
+                { layers: ["circles"] },
+              ),
+            );
+
+            console.log(layout);
+
+            setFeaturesViewport(
+              await mapViewRef.current?.queryRenderedFeatures({
+                layers: ["circles"],
+              }),
+            );
+          }}
+        />
+        <AssertEquals
+          expect={[{ ...FEATURE, ...Platform.select({ android: { id: "" } }) }]}
+          actual={featuresPoint}
+        />
+
+        <AssertEquals
+          expect={FEATURES.features.length}
+          actual={featuresBounds?.length}
+        />
+
+        <AssertEquals
+          expect={FEATURES.features.length}
+          actual={featuresViewport?.length}
+        />
+      </Bubble>
+    </View>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/ShowAttribution.tsx
+++ b/examples/shared/src/examples/e2e/map-view/ShowAttribution.tsx
@@ -1,0 +1,23 @@
+import { MapView, type MapViewRef } from "@maplibre/maplibre-react-native";
+import { useRef } from "react";
+import { Button } from "react-native";
+
+import { Bubble } from "../../../components/Bubble";
+
+export function ShowAttribution() {
+  const mapViewRef = useRef<MapViewRef>(null);
+
+  return (
+    <>
+      <MapView ref={mapViewRef} testID="map-view" />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            await mapViewRef.current?.showAttribution();
+          }}
+        />
+      </Bubble>
+    </>
+  );
+}

--- a/examples/shared/src/examples/e2e/map-view/Unproject.tsx
+++ b/examples/shared/src/examples/e2e/map-view/Unproject.tsx
@@ -1,0 +1,38 @@
+import {
+  MapView,
+  type MapViewRef,
+  type PixelPoint,
+} from "@maplibre/maplibre-react-native";
+import { useRef, useState } from "react";
+import { Button } from "react-native";
+import { z } from "zod";
+
+import { AssertZod } from "../../../components/AssertZod";
+import { Bubble } from "../../../components/Bubble";
+
+export function Unproject() {
+  const mapViewRef = useRef<MapViewRef>(null);
+  const [result, setResult] = useState<PixelPoint>();
+
+  return (
+    <>
+      <MapView ref={mapViewRef} />
+      <Bubble>
+        <Button
+          title="Act"
+          onPress={async () => {
+            setResult(await mapViewRef.current?.unproject([0, 0]));
+          }}
+        />
+
+        <AssertZod
+          schema={z.tuple([
+            z.number().min(-180).max(180),
+            z.number().min(-90).max(90),
+          ])}
+          actual={result}
+        />
+      </Bubble>
+    </>
+  );
+}

--- a/ios/components/camera/CameraStop.m
+++ b/ios/components/camera/CameraStop.m
@@ -33,8 +33,8 @@
 + (CameraStop *)fromDictionary:(NSDictionary *)args {
   CameraStop *stop = [[CameraStop alloc] init];
 
-  if (args[@"longitude"] && args[@"latitude"]) {
-    stop.center = [MLRNUtils fromLongitude:args[@"longitude"] latitude:args[@"latitude"]];
+  if (args[@"center"]) {
+    stop.center = [MLRNUtils fromLongitude:args[@"center"][0] latitude:args[@"center"][1]];
   }
 
   if (args[@"zoom"]) {

--- a/ios/components/camera/MLRNCameraComponentView.mm
+++ b/ios/components/camera/MLRNCameraComponentView.mm
@@ -89,10 +89,10 @@ using namespace facebook::react;
   if (_view.initialViewState == nil) {
     NSMutableDictionary *initialViewState = [NSMutableDictionary dictionary];
 
-    if (newViewProps.initialViewState.longitude != -360 &&
-        newViewProps.initialViewState.latitude != -360) {
-      initialViewState[@"longitude"] = @(newViewProps.initialViewState.longitude);
-      initialViewState[@"latitude"] = @(newViewProps.initialViewState.latitude);
+    if (newViewProps.initialViewState.center.size() == 2) {
+      initialViewState[@"center"] = @[
+        @(newViewProps.initialViewState.center[0]), @(newViewProps.initialViewState.center[1])
+      ];
     } else if (newViewProps.initialViewState.bounds.size() == 4) {
       initialViewState[@"bounds"] = @[
         @(newViewProps.initialViewState.bounds[0]), @(newViewProps.initialViewState.bounds[1]),
@@ -122,8 +122,7 @@ using namespace facebook::react;
 
   BOOL updateCamera = NO;
 
-  if (oldViewProps.stop.longitude != newViewProps.stop.longitude ||
-      oldViewProps.stop.latitude != newViewProps.stop.latitude ||
+  if (oldViewProps.stop.center != newViewProps.stop.center ||
 
       oldViewProps.stop.bounds != newViewProps.stop.bounds ||
       oldViewProps.stop.padding.top != newViewProps.stop.padding.top ||
@@ -139,9 +138,8 @@ using namespace facebook::react;
       oldViewProps.stop.easing != newViewProps.stop.easing) {
     NSMutableDictionary *stop = [NSMutableDictionary dictionary];
 
-    if (newViewProps.stop.longitude != -360 && newViewProps.stop.latitude != -360) {
-      stop[@"longitude"] = @(newViewProps.stop.longitude);
-      stop[@"latitude"] = @(newViewProps.stop.latitude);
+    if (newViewProps.stop.center.size() == 2) {
+      stop[@"center"] = @[ @(newViewProps.stop.center[0]), @(newViewProps.stop.center[1]) ];
     } else if (newViewProps.stop.bounds.size() == 4) {
       stop[@"bounds"] = @[
         @(newViewProps.stop.bounds[0]), @(newViewProps.stop.bounds[1]),

--- a/ios/components/camera/MLRNCameraModule.mm
+++ b/ios/components/camera/MLRNCameraModule.mm
@@ -50,9 +50,9 @@
          reject:(RCTPromiseRejectBlock)reject {
   NSMutableDictionary<NSString *, id> *stopDict = [NSMutableDictionary dictionary];
 
-  if (stop.longitude().has_value() && stop.latitude().has_value()) {
-    stopDict[@"longitude"] = @(stop.longitude().value());
-    stopDict[@"latitude"] = @(stop.latitude().value());
+  if (stop.center().has_value() && stop.center().value().size() == 2) {
+    NSArray<NSNumber *> *center = @[ @(stop.center().value()[0]), @(stop.center().value()[1]) ];
+    stopDict[@"center"] = center;
   } else if (stop.bounds().has_value() && stop.bounds().value().size() == 4) {
     NSArray<NSNumber *> *bounds = @[
       @(stop.bounds().value()[0]), @(stop.bounds().value()[1]), @(stop.bounds().value()[2]),

--- a/ios/components/map-view/MLRNMapTouchEvent.m
+++ b/ios/components/map-view/MLRNMapTouchEvent.m
@@ -10,18 +10,24 @@
   feature.coordinate = _coordinate;
   if (_id == nil) {
     feature.attributes = @{
-      @"longitude" : [NSNumber numberWithDouble:_coordinate.longitude],
-      @"latitude" : [NSNumber numberWithDouble:_coordinate.latitude],
-      @"locationX" : [NSNumber numberWithDouble:_screenPoint.x],
-      @"locationY" : [NSNumber numberWithDouble:_screenPoint.y]
+      @"lngLat" : @[
+        [NSNumber numberWithDouble:_coordinate.longitude],
+        [NSNumber numberWithDouble:_coordinate.latitude]
+      ],
+      @"point" : @[
+        [NSNumber numberWithDouble:_screenPoint.x], [NSNumber numberWithDouble:_screenPoint.y]
+      ]
     };
   } else {
     feature.attributes = @{
       @"id" : _id,
-      @"longitude" : [NSNumber numberWithDouble:_coordinate.longitude],
-      @"latitude" : [NSNumber numberWithDouble:_coordinate.latitude],
-      @"locationX" : [NSNumber numberWithDouble:_screenPoint.x],
-      @"locationY" : [NSNumber numberWithDouble:_screenPoint.y]
+      @"lngLat" : @[
+        [NSNumber numberWithDouble:_coordinate.longitude],
+        [NSNumber numberWithDouble:_coordinate.latitude]
+      ],
+      @"point" : @[
+        [NSNumber numberWithDouble:_screenPoint.x], [NSNumber numberWithDouble:_screenPoint.y]
+      ]
     };
   }
   return [feature geoJSONDictionary];

--- a/ios/components/map-view/MLRNMapView.m
+++ b/ios/components/map-view/MLRNMapView.m
@@ -294,14 +294,18 @@ static double const M2PI = M_PI * 2;
       CLLocationCoordinate2D coordinate = [mapView convertPoint:screenPoint
                                            toCoordinateFromView:mapView];
 
-      MLRNEvent *event = [MLRNEvent makeEvent:eventType
-                                  withPayload:@{
-                                    @"longitude" : [NSNumber numberWithDouble:coordinate.longitude],
-                                    @"latitude" : [NSNumber numberWithDouble:coordinate.latitude],
-                                    @"locationX" : [NSNumber numberWithDouble:screenPoint.x],
-                                    @"locationY" : [NSNumber numberWithDouble:screenPoint.y],
-                                    @"features" : geoJSONDicts,
-                                  }];
+      MLRNEvent *event = [MLRNEvent
+            makeEvent:eventType
+          withPayload:@{
+            @"lngLat" : @[
+              [NSNumber numberWithDouble:coordinate.longitude],
+              [NSNumber numberWithDouble:coordinate.latitude]
+            ],
+            @"point" : @[
+              [NSNumber numberWithDouble:screenPoint.x], [NSNumber numberWithDouble:screenPoint.y]
+            ],
+            @"features" : geoJSONDicts,
+          }];
 
       source.onPress([event toJSON]);
 
@@ -804,8 +808,10 @@ static double const M2PI = M_PI * 2;
   MLRNMapView *rctMapView = (MLRNMapView *)mapView;
 
   NSDictionary *viewState = @{
-    @"longitude" : [NSNumber numberWithDouble:mapView.centerCoordinate.longitude],
-    @"latitude" : [NSNumber numberWithDouble:mapView.centerCoordinate.latitude],
+    @"center" : @[
+      [NSNumber numberWithDouble:mapView.centerCoordinate.longitude],
+      [NSNumber numberWithDouble:mapView.centerCoordinate.latitude]
+    ],
     @"zoom" : [NSNumber numberWithDouble:mapView.zoomLevel],
     @"pitch" : [NSNumber numberWithDouble:mapView.camera.pitch],
     @"bearing" : [NSNumber numberWithDouble:mapView.camera.heading],

--- a/ios/components/map-view/MLRNMapViewComponentView.mm
+++ b/ios/components/map-view/MLRNMapViewComponentView.mm
@@ -14,26 +14,23 @@
 using namespace facebook::react;
 
 struct PressEvent {
-  double longitude;
-  double latitude;
-  double locationX;
-  double locationY;
+  folly::dynamic lngLat;
+  folly::dynamic point;
 };
 
 PressEvent createPressEvent(NSDictionary *dict) {
   PressEvent result;
 
-  result.longitude = [dict[@"properties"][@"longitude"] doubleValue];
-  result.latitude = [dict[@"properties"][@"latitude"] doubleValue];
-  result.locationX = [dict[@"properties"][@"locationX"] doubleValue];
-  result.locationY = [dict[@"properties"][@"locationY"] doubleValue];
+  result.lngLat = folly::dynamic::array([dict[@"properties"][@"lngLat"][0] doubleValue],
+                                        [dict[@"properties"][@"lngLat"][1] doubleValue]);
+  result.point = folly::dynamic::array([dict[@"properties"][@"point"][0] doubleValue],
+                                       [dict[@"properties"][@"point"][1] doubleValue]);
 
   return result;
 }
 
 struct ViewState {
-  double longitude;
-  double latitude;
+  folly::dynamic center;
   double zoom;
   double bearing;
   double pitch;
@@ -45,18 +42,15 @@ struct ViewState {
 ViewState createViewState(NSDictionary *dict) {
   ViewState result;
 
-  result.longitude = [dict[@"longitude"] doubleValue];
-  result.latitude = [dict[@"latitude"] doubleValue];
+  result.center =
+      folly::dynamic::array([dict[@"center"][0] doubleValue], [dict[@"center"][1] doubleValue]);
   result.zoom = [dict[@"zoom"] doubleValue];
   result.bearing = [dict[@"bearing"] doubleValue];
   result.pitch = [dict[@"pitch"] doubleValue];
 
-  NSArray *boundsArray = dict[@"bounds"];
-  folly::dynamic bounds = folly::dynamic::array;
-  for (NSNumber *coordinate in boundsArray) {
-    bounds.push_back([coordinate doubleValue]);
-  }
-  result.bounds = bounds;
+  result.bounds =
+      folly::dynamic::array([dict[@"bounds"][0] doubleValue], [dict[@"bounds"][1] doubleValue],
+                            [dict[@"bounds"][2] doubleValue], [dict[@"bounds"][3] doubleValue]);
 
   result.animated = [dict[@"animated"] boolValue];
   result.userInteraction = [dict[@"userInteraction"] boolValue];
@@ -109,8 +103,8 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
     if (strongSelf != nullptr && strongSelf->_eventEmitter != nullptr) {
       PressEvent pressEvent = createPressEvent(event);
 
-      facebook::react::MLRNMapViewEventEmitter::OnPress eventStruct{
-          pressEvent.longitude, pressEvent.latitude, pressEvent.locationX, pressEvent.locationY};
+      facebook::react::MLRNMapViewEventEmitter::OnPress eventStruct{pressEvent.lngLat,
+                                                                    pressEvent.point};
 
       std::dynamic_pointer_cast<const facebook::react::MLRNMapViewEventEmitter>(
           strongSelf->_eventEmitter)
@@ -124,8 +118,8 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
     if (strongSelf != nullptr && strongSelf->_eventEmitter != nullptr) {
       PressEvent pressEvent = createPressEvent(event);
 
-      facebook::react::MLRNMapViewEventEmitter::OnLongPress eventStruct{
-          pressEvent.longitude, pressEvent.latitude, pressEvent.locationX, pressEvent.locationY};
+      facebook::react::MLRNMapViewEventEmitter::OnLongPress eventStruct{pressEvent.lngLat,
+                                                                        pressEvent.point};
 
       std::dynamic_pointer_cast<const facebook::react::MLRNMapViewEventEmitter>(
           strongSelf->_eventEmitter)
@@ -140,8 +134,8 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
       ViewState viewState = createViewState(event);
 
       facebook::react::MLRNMapViewEventEmitter::OnRegionWillChange eventStruct{
-          viewState.longitude, viewState.latitude, viewState.zoom,     viewState.bearing,
-          viewState.pitch,     viewState.bounds,   viewState.animated, viewState.userInteraction};
+          viewState.center, viewState.zoom,     viewState.bearing,        viewState.pitch,
+          viewState.bounds, viewState.animated, viewState.userInteraction};
 
       std::dynamic_pointer_cast<const facebook::react::MLRNMapViewEventEmitter>(
           strongSelf->_eventEmitter)
@@ -155,8 +149,8 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
       ViewState viewState = createViewState(event);
 
       facebook::react::MLRNMapViewEventEmitter::OnRegionIsChanging eventStruct{
-          viewState.longitude, viewState.latitude, viewState.zoom,     viewState.bearing,
-          viewState.pitch,     viewState.bounds,   viewState.animated, viewState.userInteraction};
+          viewState.center, viewState.zoom,     viewState.bearing,        viewState.pitch,
+          viewState.bounds, viewState.animated, viewState.userInteraction};
 
       std::dynamic_pointer_cast<const facebook::react::MLRNMapViewEventEmitter>(
           strongSelf->_eventEmitter)
@@ -170,8 +164,8 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
       ViewState viewState = createViewState(event);
 
       facebook::react::MLRNMapViewEventEmitter::OnRegionDidChange eventStruct{
-          viewState.longitude, viewState.latitude, viewState.zoom,     viewState.bearing,
-          viewState.pitch,     viewState.bounds,   viewState.animated, viewState.userInteraction};
+          viewState.center, viewState.zoom,     viewState.bearing,        viewState.pitch,
+          viewState.bounds, viewState.animated, viewState.userInteraction};
 
       std::dynamic_pointer_cast<const facebook::react::MLRNMapViewEventEmitter>(
           strongSelf->_eventEmitter)
@@ -308,8 +302,8 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
 
   if (oldViewProps.light != newViewProps.light) {
     NSDictionary *reactLight = (!newViewProps.light.isNull() && newViewProps.light.isObject())
-        ? convertFollyDynamicToNSDictionary(newViewProps.light)
-        : nil;
+                                   ? convertFollyDynamicToNSDictionary(newViewProps.light)
+                                   : nil;
     [_view setReactLight:reactLight];
   }
 

--- a/ios/components/map-view/MLRNMapViewManager.h
+++ b/ios/components/map-view/MLRNMapViewManager.h
@@ -42,19 +42,19 @@
          resolve:(RCTPromiseResolveBlock _Nonnull)resolve
           reject:(RCTPromiseRejectBlock _Nonnull)reject;
 
-+ (void)queryRenderedFeaturesWithCoordinate:(MLRNMapView *_Nonnull)view
-                                 coordinate:(CLLocationCoordinate2D)coordinate
++ (void)queryRenderedFeaturesWithPoint:(MLRNMapView *_Nonnull)view
+                                 point:(CGPoint)point
                                    layerIds:(NSSet *_Nonnull)layerIds
                                   predicate:(NSPredicate *_Nonnull)predicate
                                     resolve:(RCTPromiseResolveBlock _Nonnull)resolve
                                      reject:(RCTPromiseRejectBlock _Nonnull)reject;
 
-+ (void)queryRenderedFeaturesWithBounds:(MLRNMapView *_Nonnull)view
-                                 bounds:(MLNCoordinateBounds)bounds
-                               layerIds:(NSSet *_Nonnull)layerIds
-                              predicate:(NSPredicate *_Nonnull)predicate
-                                resolve:(RCTPromiseResolveBlock _Nonnull)resolve
-                                 reject:(RCTPromiseRejectBlock _Nonnull)reject;
++ (void)queryRenderedFeaturesWithRect:(MLRNMapView *_Nonnull)view
+                                 rect:(CGRect)rect
+                             layerIds:(NSSet *_Nonnull)layerIds
+                            predicate:(NSPredicate *_Nonnull)predicate
+                              resolve:(RCTPromiseResolveBlock _Nonnull)resolve
+                               reject:(RCTPromiseRejectBlock _Nonnull)reject;
 
 + (void)showAttribution:(MLRNMapView *_Nonnull)view
                 resolve:(RCTPromiseResolveBlock _Nonnull)resolve

--- a/ios/components/map-view/MLRNMapViewManager.m
+++ b/ios/components/map-view/MLRNMapViewManager.m
@@ -20,10 +20,7 @@
 + (void)getCenter:(MLRNMapView *)view
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject {
-  resolve(@{
-    @"longitude" : @(view.centerCoordinate.longitude),
-    @"latitude" : @(view.centerCoordinate.latitude)
-  });
+  resolve(@[ @(view.centerCoordinate.longitude), @(view.centerCoordinate.latitude) ]);
 }
 
 + (void)getZoom:(MLRNMapView *)view
@@ -53,10 +50,7 @@
 + (void)getViewState:(MLRNMapView *)view
              resolve:(RCTPromiseResolveBlock)resolve
               reject:(RCTPromiseRejectBlock)reject {
-  NSDictionary *center = @{
-    @"longitude" : @(view.centerCoordinate.longitude),
-    @"latitude" : @(view.centerCoordinate.latitude)
-  };
+  NSArray *center = @[ @(view.centerCoordinate.longitude), @(view.centerCoordinate.latitude) ];
   NSNumber *zoom = @(view.zoomLevel);
   NSNumber *bearing = @(view.camera.heading);
   NSNumber *pitch = @(view.camera.pitch);
@@ -83,7 +77,7 @@
          reject:(RCTPromiseRejectBlock)reject {
   CGPoint point = [self project:view coordinate:coordinate];
 
-  resolve(@{@"locationX" : @(point.x), @"locationY" : @(point.y)});
+  resolve(@[ @(point.x), @(point.y) ]);
 }
 
 + (void)unproject:(MLRNMapView *)view
@@ -92,7 +86,7 @@
            reject:(RCTPromiseRejectBlock)reject {
   CLLocationCoordinate2D coordinate = [view convertPoint:point toCoordinateFromView:view];
 
-  resolve(@{@"longitude" : @(coordinate.longitude), @"latitude" : @(coordinate.latitude)});
+  resolve(@[ @(coordinate.longitude), @(coordinate.latitude) ]);
 }
 
 + (void)takeSnap:(MLRNMapView *)view
@@ -103,14 +97,12 @@
   resolve(uri);
 }
 
-+ (void)queryRenderedFeaturesWithCoordinate:(MLRNMapView *)view
-                                 coordinate:(CLLocationCoordinate2D)coordinate
-                                   layerIds:(NSSet *)layerIds
-                                  predicate:(NSPredicate *)predicate
-                                    resolve:(RCTPromiseResolveBlock)resolve
-                                     reject:(RCTPromiseRejectBlock)reject {
-  CGPoint point = [self project:view coordinate:coordinate];
-
++ (void)queryRenderedFeaturesWithPoint:(MLRNMapView *)view
+                                 point:(CGPoint)point
+                              layerIds:(NSSet *)layerIds
+                             predicate:(NSPredicate *)predicate
+                               resolve:(RCTPromiseResolveBlock)resolve
+                                reject:(RCTPromiseRejectBlock)reject {
   NSArray<id<MLNFeature>> *shapes = [view visibleFeaturesAtPoint:point
                                     inStyleLayersWithIdentifiers:layerIds
                                                        predicate:predicate];
@@ -120,27 +112,22 @@
     [features addObject:shapes[i].geoJSONDictionary];
   }
 
-  resolve(@{@"type" : @"FeatureCollection", @"features" : features});
+  resolve(features);
 }
 
-+ (void)queryRenderedFeaturesWithBounds:(MLRNMapView *)view
-                                 bounds:(MLNCoordinateBounds)bounds
-                               layerIds:(NSSet *)layerIds
-                              predicate:(NSPredicate *)predicate
-                                resolve:(RCTPromiseResolveBlock)resolve
-                                 reject:(RCTPromiseRejectBlock)reject {
-  CGPoint swPoint = [self project:view coordinate:bounds.sw];
-  CGPoint nePoint = [self project:view coordinate:bounds.ne];
-
-  CGRect bbox = CGRectMake(swPoint.x, swPoint.y, nePoint.x - swPoint.x, nePoint.y - swPoint.y);
-
-  NSArray<id<MLNFeature>> *shapes = [view visibleFeaturesInRect:bbox
++ (void)queryRenderedFeaturesWithRect:(MLRNMapView *)view
+                                 rect:(CGRect)rect
+                             layerIds:(NSSet *)layerIds
+                            predicate:(NSPredicate *)predicate
+                              resolve:(RCTPromiseResolveBlock)resolve
+                               reject:(RCTPromiseRejectBlock)reject {
+  NSArray<id<MLNFeature>> *shapes = [view visibleFeaturesInRect:rect
                                    inStyleLayersWithIdentifiers:layerIds
                                                       predicate:predicate];
 
   NSArray<NSDictionary *> *features = [MLRNUtils featuresToJSON:shapes];
 
-  resolve(@{@"type" : @"FeatureCollection", @"features" : features});
+  resolve(features);
 }
 
 + (void)showAttribution:(MLRNMapView *)view

--- a/ios/components/map-view/MLRNMapViewManager.m
+++ b/ios/components/map-view/MLRNMapViewManager.m
@@ -32,7 +32,8 @@
 + (void)getBearing:(MLRNMapView *)view
            resolve:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject {
-  resolve(@(view.camera.heading));
+  // Convert -0.0 to 0.0
+  resolve(@(view.camera.heading + 0.0));
 }
 
 + (void)getPitch:(MLRNMapView *)view

--- a/ios/components/map-view/MLRNMapViewManager.m
+++ b/ios/components/map-view/MLRNMapViewManager.m
@@ -56,7 +56,8 @@
   NSNumber *pitch = @(view.camera.pitch);
   NSArray *bounds = [MLRNUtils fromCoordinateBounds:view.visibleCoordinateBounds];
 
-  NSMutableDictionary *payload = [center mutableCopy];
+  NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+  payload[@"center"] = center;
   payload[@"zoom"] = zoom;
   payload[@"bearing"] = bearing;
   payload[@"pitch"] = pitch;

--- a/ios/components/map-view/MLRNMapViewModule.mm
+++ b/ios/components/map-view/MLRNMapViewModule.mm
@@ -112,16 +112,16 @@
 }
 
 - (void)project:(NSInteger)reactTag
-     coordinate:(JS::NativeMapViewModule::SpecProjectCoordinate &)coordinate
+         lngLat:(NSArray<NSNumber *> *)lngLat
         resolve:(RCTPromiseResolveBlock)resolve
          reject:(RCTPromiseRejectBlock)reject {
-  CLLocationCoordinate2D transformedCoordinate =
-      CLLocationCoordinate2DMake(coordinate.latitude(), coordinate.longitude());
+  CLLocationCoordinate2D coordinate =
+      CLLocationCoordinate2DMake([lngLat[0] doubleValue], [lngLat[1] doubleValue]);
 
   [self withMapView:reactTag
               block:^(MLRNMapView *view) {
                 [MLRNMapViewManager project:view
-                                 coordinate:transformedCoordinate
+                                 coordinate:coordinate
                                     resolve:resolve
                                      reject:reject];
               }
@@ -130,17 +130,14 @@
 }
 
 - (void)unproject:(NSInteger)reactTag
-            point:(JS::NativeMapViewModule::SpecUnprojectPoint &)point
+       pixelPoint:(NSArray<NSNumber *> *)pixelPoint
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject {
-  CGPoint transformedPoint = CGPointMake(point.locationX(), point.locationY());
+  CGPoint point = CGPointMake([pixelPoint[0] doubleValue], [pixelPoint[1] doubleValue]);
 
   [self withMapView:reactTag
               block:^(MLRNMapView *view) {
-                [MLRNMapViewManager unproject:view
-                                        point:transformedPoint
-                                      resolve:resolve
-                                       reject:reject];
+                [MLRNMapViewManager unproject:view point:point resolve:resolve reject:reject];
               }
              reject:reject
          methodName:@"unproject"];
@@ -161,17 +158,13 @@
          methodName:@"takeSnap"];
 }
 
-- (void)queryRenderedFeaturesWithCoordinate:(NSInteger)reactTag
-                                 coordinate:
-                                     (JS::NativeMapViewModule::
-                                          SpecQueryRenderedFeaturesWithCoordinateCoordinate &)
-                                         coordinate
-                                     layers:(nonnull NSArray<NSString *> *)layers
-                                     filter:(nonnull NSArray *)filter
-                                    resolve:(nonnull RCTPromiseResolveBlock)resolve
-                                     reject:(nonnull RCTPromiseRejectBlock)reject {
-  CLLocationCoordinate2D transformedCoordinate =
-      CLLocationCoordinate2DMake(coordinate.latitude(), coordinate.longitude());
+- (void)queryRenderedFeaturesWithPoint:(NSInteger)reactTag
+                            pixelPoint:(NSArray<NSNumber *> *)pixelPoint
+                                layers:(nonnull NSArray<NSString *> *)layers
+                                filter:(nonnull NSArray *)filter
+                               resolve:(nonnull RCTPromiseResolveBlock)resolve
+                                reject:(nonnull RCTPromiseRejectBlock)reject {
+  CGPoint point = CGPointMake([pixelPoint[0] doubleValue], [pixelPoint[1] doubleValue]);
 
   [self withMapView:reactTag
               block:^(MLRNMapView *view) {
@@ -182,26 +175,37 @@
 
                 NSPredicate *predicate = [FilterParser parse:filter];
 
-                [MLRNMapViewManager queryRenderedFeaturesWithCoordinate:view
-                                                             coordinate:transformedCoordinate
-                                                               layerIds:layerIdSet
-                                                              predicate:predicate
-                                                                resolve:resolve
-                                                                 reject:reject];
+                [MLRNMapViewManager queryRenderedFeaturesWithPoint:view
+                                                             point:point
+                                                          layerIds:layerIdSet
+                                                         predicate:predicate
+                                                           resolve:resolve
+                                                            reject:reject];
               }
              reject:reject
          methodName:@"queryRenderedFeaturesWithCoordinate"];
 }
 
 - (void)queryRenderedFeaturesWithBounds:(NSInteger)reactTag
-                                 bounds:(NSArray<NSNumber *> *)bounds
+                       pixelPointBounds:(NSArray<NSArray<NSNumber *> *> *)pixelPointBounds
                                  layers:(NSArray<NSString *> *)layers
                                  filter:(NSArray *)filter
                                 resolve:(RCTPromiseResolveBlock)resolve
                                  reject:(RCTPromiseRejectBlock)reject {
   [self withMapView:reactTag
               block:^(MLRNMapView *view) {
-                MLNCoordinateBounds coordinateBounds = [MLRNUtils fromReactBounds:bounds];
+                CGRect rect;
+
+                if (pixelPointBounds == nil) {
+                  rect = view.bounds;
+                } else {
+                  CGFloat left = [pixelPointBounds[0][0] doubleValue];
+                  CGFloat top = [pixelPointBounds[0][1] doubleValue];
+                  CGFloat right = [pixelPointBounds[1][0] doubleValue];
+                  CGFloat bottom = [pixelPointBounds[1][1] doubleValue];
+
+                  rect = CGRectMake(left, top, right - left, bottom - top);
+                }
 
                 NSSet *layerIdSet = nil;
                 if (layers != nil && layers.count > 0) {
@@ -210,15 +214,15 @@
 
                 NSPredicate *predicate = [FilterParser parse:filter];
 
-                [MLRNMapViewManager queryRenderedFeaturesWithBounds:view
-                                                             bounds:coordinateBounds
-                                                           layerIds:layerIdSet
-                                                          predicate:predicate
-                                                            resolve:resolve
-                                                             reject:reject];
+                [MLRNMapViewManager queryRenderedFeaturesWithRect:view
+                                                             rect:rect
+                                                         layerIds:layerIdSet
+                                                        predicate:predicate
+                                                          resolve:resolve
+                                                           reject:reject];
               }
              reject:reject
-         methodName:@"queryRenderedFeaturesInRect"];
+         methodName:@"queryRenderedFeaturesWithBounds"];
 }
 
 - (void)showAttribution:(NSInteger)reactTag

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,9 @@ import { type Config } from "jest";
 const config: Config = {
   preset: "react-native",
 
+  moduleNameMapper: {
+    "^@maplibre/maplibre-react-native$": "<rootDir>/src/index.ts",
+  },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   setupFilesAfterEnv: [
     "./src/__tests__/__mocks__/react-native.mock.ts",
@@ -17,4 +20,4 @@ const config: Config = {
   collectCoverageFrom: ["src/**/*.{ts,tsx,js,jsx}"],
 };
 
-export default config;
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "eslint": "^8.57.1",
     "eslint-config-universe": "15.0.3",
     "expo-module-scripts": "^5.0.7",
-    "jest": "^30.1.3",
+    "jest": "^29.7.0",
     "prettier": "3.6.2",
     "react": "19.1.0",
     "react-docgen": "^8.0.1",

--- a/src/__tests__/__mocks__/NativeModules.mock.ts
+++ b/src/__tests__/__mocks__/NativeModules.mock.ts
@@ -79,7 +79,21 @@ export const mockNativeModules: Record<string, any> = {
     setLogLevel: jest.fn(),
   },
 
-  MLRNMapViewModule: {},
+  MLRNMapViewModule: {
+    getCenter: jest.fn(),
+    getZoom: jest.fn(),
+    getBearing: jest.fn(),
+    getPitch: jest.fn(),
+    getBounds: jest.fn(),
+    getViewState: jest.fn(),
+    project: jest.fn(),
+    unproject: jest.fn(),
+    queryRenderedFeaturesWithPoint: jest.fn(),
+    queryRenderedFeaturesWithBounds: jest.fn(),
+    takeSnap: jest.fn(),
+    setSourceVisibility: jest.fn(),
+    showAttribution: jest.fn(),
+  },
 
   MLRNSnapshotModule: {
     takeSnap: () => {

--- a/src/__tests__/components/Camera.test.tsx
+++ b/src/__tests__/components/Camera.test.tsx
@@ -1,3 +1,4 @@
+import type { CameraStop, LngLat } from "@maplibre/maplibre-react-native";
 import { render } from "@testing-library/react-native";
 import { createRef } from "react";
 
@@ -6,7 +7,7 @@ import {
   type CameraProps,
   type CameraRef,
 } from "../../components/camera/Camera";
-import type { Bounds } from "../../types/Bounds";
+import type { LngLatBounds } from "../../types/LngLatBounds";
 import type { ViewPadding } from "../../types/ViewPadding";
 import { mockNativeModules } from "../__mocks__/NativeModules.mock";
 
@@ -36,8 +37,8 @@ function renderCamera(props: CameraProps = {}) {
   };
 }
 
-const CENTER = { longitude: 1, latitude: 2 };
-const BOUNDS: Bounds = [1, 2, 3, 4];
+const CENTER: LngLat = [1, 2];
+const BOUNDS: LngLatBounds = [1, 2, 3, 4];
 const PADDING: ViewPadding = { top: 1, right: 2, bottom: 3, left: 4 };
 
 describe("Camera", () => {
@@ -220,15 +221,14 @@ describe("Camera", () => {
     test("`jumpTo` calls `setStop`", () => {
       const { cameraRef } = renderCamera();
       cameraRef.current.jumpTo({
-        center: { longitude: 1, latitude: 2 },
+        center: [1, 2],
         zoom: 5,
       });
 
       expect(mockNativeModules.MLRNCameraModule.setStop).toHaveBeenCalledWith(
         expect.any(Number),
         expect.objectContaining({
-          longitude: 1,
-          latitude: 2,
+          center: [1, 2],
           zoom: 5,
           duration: 0,
           easing: undefined,
@@ -239,15 +239,14 @@ describe("Camera", () => {
     test("`easeTo` calls `setStop`", () => {
       const { cameraRef } = renderCamera();
       cameraRef.current.easeTo({
-        center: { longitude: 3, latitude: 4 },
+        center: [3, 4],
         zoom: 7,
       });
 
       expect(mockNativeModules.MLRNCameraModule.setStop).toHaveBeenCalledWith(
         expect.any(Number),
         expect.objectContaining({
-          longitude: 3,
-          latitude: 4,
+          center: [3, 4],
           zoom: 7,
           duration: 500,
           easing: "ease",
@@ -258,15 +257,14 @@ describe("Camera", () => {
     test("`flyTo` calls `setStop`", () => {
       const { cameraRef } = renderCamera();
       cameraRef.current.flyTo({
-        center: { longitude: 5, latitude: 6 },
+        center: [5, 6],
         zoom: 8,
       });
 
       expect(mockNativeModules.MLRNCameraModule.setStop).toHaveBeenCalledWith(
         expect.any(Number),
         expect.objectContaining({
-          longitude: 5,
-          latitude: 6,
+          center: [5, 6],
           zoom: 8,
           duration: 2000,
           easing: "fly",
@@ -301,12 +299,11 @@ describe("Camera", () => {
     test("`setStop` calls correctly", () => {
       const { cameraRef } = renderCamera();
       const stop = {
-        longitude: 7,
-        latitude: 8,
+        center: [7, 8],
         zoom: 9,
         duration: 1000,
         easing: "linear",
-      } as const;
+      } as const satisfies CameraStop;
       cameraRef.current.setStop(stop);
 
       expect(mockNativeModules.MLRNCameraModule.setStop).toHaveBeenCalledWith(

--- a/src/__tests__/components/MapView.test.tsx
+++ b/src/__tests__/components/MapView.test.tsx
@@ -1,25 +1,16 @@
-import type {
-  LngLat,
-  PixelPoint,
-  PixelPointBounds,
+import {
   MapView,
   type MapViewProps,
   type MapViewRef,
+  type PixelPointBounds,
+  type PixelPoint,
+  type LngLatBounds,
+  type LngLat,
 } from "@maplibre/maplibre-react-native";
 import { render, fireEvent } from "@testing-library/react-native";
 import { createRef } from "react";
 
-import type { LngLatBounds } from "../../types/LngLatBounds";
 import { mockNativeModules } from "../__mocks__/NativeModules.mock";
-
-// Mock findNodeHandle to return a valid tag
-jest.mock("react-native", () => {
-  const actualReactNative = jest.requireActual("react-native");
-  return {
-    ...actualReactNative,
-    findNodeHandle: jest.fn(() => 1),
-  };
-});
 
 const TEST_ID = "MLRNMapView";
 
@@ -27,12 +18,11 @@ function renderMapView(props: MapViewProps = {}) {
   const mapViewRef = createRef<MapViewRef>();
 
   const result = render(
-    <MapView testID={TEST_ID} {...props} ref={mapViewRef} />,
+    <MapView {...props} testID={TEST_ID} ref={mapViewRef} />,
   );
 
-  // Trigger onLayout to make the map ready
-  const container = result.getByTestId(TEST_ID);
-  fireEvent(container, "layout");
+  const view = result.getByTestId(`${TEST_ID}View`);
+  fireEvent(view, "layout");
 
   if (mapViewRef.current === null) {
     throw new Error("Refs can't be null");
@@ -50,51 +40,10 @@ const BOUNDS: LngLatBounds = [-74.0, 40.7, -73.9, 40.8];
 describe("MapView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
 
-    // Setup default mocks for MapView module
-    mockNativeModules.MLRNMapViewModule.getCenter = jest.fn(() =>
-      Promise.resolve(CENTER),
-    );
-    mockNativeModules.MLRNMapViewModule.getZoom = jest.fn(() =>
-      Promise.resolve(16),
-    );
-    mockNativeModules.MLRNMapViewModule.getBearing = jest.fn(() =>
-      Promise.resolve(45),
-    );
-    mockNativeModules.MLRNMapViewModule.getPitch = jest.fn(() =>
-      Promise.resolve(30),
-    );
-    mockNativeModules.MLRNMapViewModule.getBounds = jest.fn(() =>
-      Promise.resolve(BOUNDS),
-    );
-    mockNativeModules.MLRNMapViewModule.getViewState = jest.fn(() =>
-      Promise.resolve({
-        center: CENTER,
-        zoom: 16,
-        bearing: 45,
-        pitch: 30,
-        bounds: BOUNDS,
-      }),
-    );
-    mockNativeModules.MLRNMapViewModule.project = jest.fn(() =>
-      Promise.resolve([100, 200]),
-    );
-    mockNativeModules.MLRNMapViewModule.unproject = jest.fn(() =>
-      Promise.resolve(CENTER),
-    );
-    mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithPoint =
-      jest.fn(() => Promise.resolve([]));
-    mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithBounds =
-      jest.fn(() => Promise.resolve([]));
-    mockNativeModules.MLRNMapViewModule.takeSnap = jest.fn(() =>
-      Promise.resolve("file://snapshot.png"),
-    );
-    mockNativeModules.MLRNMapViewModule.setSourceVisibility = jest.fn(() =>
-      Promise.resolve(),
-    );
-    mockNativeModules.MLRNMapViewModule.showAttribution = jest.fn(() =>
-      Promise.resolve(),
-    );
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("renders", () => {
@@ -108,7 +57,7 @@ describe("MapView", () => {
       const style = { flex: 2, backgroundColor: "red" };
       const { getByTestId } = renderMapView({ style });
 
-      expect(getByTestId(TEST_ID).props.style).toEqual(style);
+      expect(getByTestId(`${TEST_ID}View`).props.style).toEqual(style);
     });
   });
 
@@ -132,6 +81,10 @@ describe("MapView", () => {
     });
 
     test("getCenter", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "getCenter")
+        .mockResolvedValue(CENTER);
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.getCenter();
 
@@ -142,6 +95,10 @@ describe("MapView", () => {
     });
 
     test("getZoom", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "getZoom")
+        .mockResolvedValue(16);
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.getZoom();
 
@@ -152,6 +109,10 @@ describe("MapView", () => {
     });
 
     test("getBearing", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "getBearing")
+        .mockResolvedValue(45);
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.getBearing();
 
@@ -162,6 +123,10 @@ describe("MapView", () => {
     });
 
     test("getPitch", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "getPitch")
+        .mockResolvedValue(30);
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.getPitch();
 
@@ -172,6 +137,10 @@ describe("MapView", () => {
     });
 
     test("getBounds", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "getBounds")
+        .mockResolvedValue(BOUNDS);
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.getBounds();
 
@@ -182,6 +151,16 @@ describe("MapView", () => {
     });
 
     test("getViewState", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "getViewState")
+        .mockResolvedValue({
+          center: CENTER,
+          zoom: 16,
+          bearing: 45,
+          pitch: 30,
+          bounds: BOUNDS,
+        });
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.getViewState();
 
@@ -198,6 +177,10 @@ describe("MapView", () => {
     });
 
     test("project", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "project")
+        .mockResolvedValue([100, 200]);
+
       const { mapViewRef } = renderMapView();
       const lngLat: LngLat = [-73.99155, 40.73581];
       const result = await mapViewRef.current.project(lngLat);
@@ -210,6 +193,10 @@ describe("MapView", () => {
     });
 
     test("unproject", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "unproject")
+        .mockResolvedValue(CENTER);
+
       const { mapViewRef } = renderMapView();
       const pixelPoint: PixelPoint = [100, 200];
       const result = await mapViewRef.current.unproject(pixelPoint);
@@ -222,6 +209,13 @@ describe("MapView", () => {
 
     describe("queryRenderedFeatures", () => {
       test("with pixel point", async () => {
+        jest
+          .spyOn(
+            mockNativeModules.MLRNMapViewModule,
+            "queryRenderedFeaturesWithPoint",
+          )
+          .mockResolvedValue([]);
+
         const { mapViewRef } = renderMapView();
         const pixelPoint: PixelPoint = [100, 200];
         const options = {
@@ -242,6 +236,13 @@ describe("MapView", () => {
       });
 
       test("with pixel bounds", async () => {
+        jest
+          .spyOn(
+            mockNativeModules.MLRNMapViewModule,
+            "queryRenderedFeaturesWithBounds",
+          )
+          .mockResolvedValue([]);
+
         const { mapViewRef } = renderMapView();
         const pixelPointBounds: PixelPointBounds = [
           [100, 100],
@@ -268,6 +269,13 @@ describe("MapView", () => {
       });
 
       test("with no bounds (whole viewport)", async () => {
+        jest
+          .spyOn(
+            mockNativeModules.MLRNMapViewModule,
+            "queryRenderedFeaturesWithBounds",
+          )
+          .mockResolvedValue([]);
+
         const { mapViewRef } = renderMapView();
         const options = {
           layers: ["layer1"],
@@ -281,6 +289,13 @@ describe("MapView", () => {
       });
 
       test("with no options", async () => {
+        jest
+          .spyOn(
+            mockNativeModules.MLRNMapViewModule,
+            "queryRenderedFeaturesWithBounds",
+          )
+          .mockResolvedValue([]);
+
         const { mapViewRef } = renderMapView();
 
         await mapViewRef.current.queryRenderedFeatures();
@@ -292,6 +307,10 @@ describe("MapView", () => {
     });
 
     test("takeSnap with writeToDisk=false", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "takeSnap")
+        .mockResolvedValue("file://test.png");
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.takeSnap(false);
 
@@ -299,10 +318,14 @@ describe("MapView", () => {
         expect.any(Number),
         false,
       );
-      expect(result).toBe("file://snapshot.png");
+      expect(result).toBe("file://test.png");
     });
 
     test("takeSnap with writeToDisk=true", async () => {
+      jest
+        .spyOn(mockNativeModules.MLRNMapViewModule, "takeSnap")
+        .mockResolvedValue("file://test.png");
+
       const { mapViewRef } = renderMapView();
       const result = await mapViewRef.current.takeSnap(true);
 
@@ -310,7 +333,7 @@ describe("MapView", () => {
         expect.any(Number),
         true,
       );
-      expect(result).toBe("file://snapshot.png");
+      expect(result).toBe("file://test.png");
     });
 
     test("setSourceVisibility", async () => {

--- a/src/__tests__/components/MapView.test.tsx
+++ b/src/__tests__/components/MapView.test.tsx
@@ -1,25 +1,352 @@
-import { render } from "@testing-library/react-native";
+import type {
+  LngLat,
+  PixelPoint,
+  PixelPointBounds,
+  MapView,
+  type MapViewProps,
+  type MapViewRef,
+} from "@maplibre/maplibre-react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import { createRef } from "react";
 
-import { MapView } from "../..";
+import type { LngLatBounds } from "../../types/LngLatBounds";
+import { mockNativeModules } from "../__mocks__/NativeModules.mock";
+
+// Mock findNodeHandle to return a valid tag
+jest.mock("react-native", () => {
+  const actualReactNative = jest.requireActual("react-native");
+  return {
+    ...actualReactNative,
+    findNodeHandle: jest.fn(() => 1),
+  };
+});
 
 const TEST_ID = "MLRNMapView";
 
-describe("MapView", () => {
-  test("renders with testID", () => {
-    const { getByTestId } = render(<MapView testID={TEST_ID} />);
+function renderMapView(props: MapViewProps = {}) {
+  const mapViewRef = createRef<MapViewRef>();
 
-    expect(getByTestId(TEST_ID)).toBeDefined();
+  const result = render(
+    <MapView testID={TEST_ID} {...props} ref={mapViewRef} />,
+  );
+
+  // Trigger onLayout to make the map ready
+  const container = result.getByTestId(TEST_ID);
+  fireEvent(container, "layout");
+
+  if (mapViewRef.current === null) {
+    throw new Error("Refs can't be null");
+  }
+
+  return {
+    ...result,
+    mapViewRef: { current: mapViewRef.current },
+  };
+}
+
+const CENTER: LngLat = [-73.99155, 40.73581];
+const BOUNDS: LngLatBounds = [-74.0, 40.7, -73.9, 40.8];
+
+describe("MapView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup default mocks for MapView module
+    mockNativeModules.MLRNMapViewModule.getCenter = jest.fn(() =>
+      Promise.resolve(CENTER),
+    );
+    mockNativeModules.MLRNMapViewModule.getZoom = jest.fn(() =>
+      Promise.resolve(16),
+    );
+    mockNativeModules.MLRNMapViewModule.getBearing = jest.fn(() =>
+      Promise.resolve(45),
+    );
+    mockNativeModules.MLRNMapViewModule.getPitch = jest.fn(() =>
+      Promise.resolve(30),
+    );
+    mockNativeModules.MLRNMapViewModule.getBounds = jest.fn(() =>
+      Promise.resolve(BOUNDS),
+    );
+    mockNativeModules.MLRNMapViewModule.getViewState = jest.fn(() =>
+      Promise.resolve({
+        center: CENTER,
+        zoom: 16,
+        bearing: 45,
+        pitch: 30,
+        bounds: BOUNDS,
+      }),
+    );
+    mockNativeModules.MLRNMapViewModule.project = jest.fn(() =>
+      Promise.resolve([100, 200]),
+    );
+    mockNativeModules.MLRNMapViewModule.unproject = jest.fn(() =>
+      Promise.resolve(CENTER),
+    );
+    mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithPoint =
+      jest.fn(() => Promise.resolve([]));
+    mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithBounds =
+      jest.fn(() => Promise.resolve([]));
+    mockNativeModules.MLRNMapViewModule.takeSnap = jest.fn(() =>
+      Promise.resolve("file://snapshot.png"),
+    );
+    mockNativeModules.MLRNMapViewModule.setSourceVisibility = jest.fn(() =>
+      Promise.resolve(),
+    );
+    mockNativeModules.MLRNMapViewModule.showAttribution = jest.fn(() =>
+      Promise.resolve(),
+    );
   });
 
-  test("renders with light prop", () => {
-    const light = {
-      position: [1.5, 90, 80],
-      color: "#ffffff",
-      intensity: 0.5,
-    };
+  describe("renders", () => {
+    test("correctly", () => {
+      const { getByTestId } = renderMapView();
 
-    const { getByTestId } = render(<MapView testID={TEST_ID} light={light} />);
+      expect(getByTestId(TEST_ID)).toBeDefined();
+    });
 
-    expect(getByTestId(TEST_ID)).toBeDefined();
+    test("with custom style", () => {
+      const style = { flex: 2, backgroundColor: "red" };
+      const { getByTestId } = renderMapView({ style });
+
+      expect(getByTestId(TEST_ID).props.style).toEqual(style);
+    });
+  });
+
+  describe("imperative methods", () => {
+    test("are exposed", () => {
+      const { mapViewRef } = renderMapView();
+
+      expect(mapViewRef.current).toBeDefined();
+      expect(typeof mapViewRef.current.getCenter).toBe("function");
+      expect(typeof mapViewRef.current.getZoom).toBe("function");
+      expect(typeof mapViewRef.current.getBearing).toBe("function");
+      expect(typeof mapViewRef.current.getPitch).toBe("function");
+      expect(typeof mapViewRef.current.getBounds).toBe("function");
+      expect(typeof mapViewRef.current.getViewState).toBe("function");
+      expect(typeof mapViewRef.current.project).toBe("function");
+      expect(typeof mapViewRef.current.unproject).toBe("function");
+      expect(typeof mapViewRef.current.queryRenderedFeatures).toBe("function");
+      expect(typeof mapViewRef.current.takeSnap).toBe("function");
+      expect(typeof mapViewRef.current.setSourceVisibility).toBe("function");
+      expect(typeof mapViewRef.current.showAttribution).toBe("function");
+    });
+
+    test("getCenter", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.getCenter();
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.getCenter,
+      ).toHaveBeenCalledWith(expect.any(Number));
+      expect(result).toEqual(CENTER);
+    });
+
+    test("getZoom", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.getZoom();
+
+      expect(mockNativeModules.MLRNMapViewModule.getZoom).toHaveBeenCalledWith(
+        expect.any(Number),
+      );
+      expect(result).toBe(16);
+    });
+
+    test("getBearing", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.getBearing();
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.getBearing,
+      ).toHaveBeenCalledWith(expect.any(Number));
+      expect(result).toBe(45);
+    });
+
+    test("getPitch", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.getPitch();
+
+      expect(mockNativeModules.MLRNMapViewModule.getPitch).toHaveBeenCalledWith(
+        expect.any(Number),
+      );
+      expect(result).toBe(30);
+    });
+
+    test("getBounds", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.getBounds();
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.getBounds,
+      ).toHaveBeenCalledWith(expect.any(Number));
+      expect(result).toEqual(BOUNDS);
+    });
+
+    test("getViewState", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.getViewState();
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.getViewState,
+      ).toHaveBeenCalledWith(expect.any(Number));
+      expect(result).toEqual({
+        center: CENTER,
+        zoom: 16,
+        bearing: 45,
+        pitch: 30,
+        bounds: BOUNDS,
+      });
+    });
+
+    test("project", async () => {
+      const { mapViewRef } = renderMapView();
+      const lngLat: LngLat = [-73.99155, 40.73581];
+      const result = await mapViewRef.current.project(lngLat);
+
+      expect(mockNativeModules.MLRNMapViewModule.project).toHaveBeenCalledWith(
+        expect.any(Number),
+        lngLat,
+      );
+      expect(result).toEqual([100, 200]);
+    });
+
+    test("unproject", async () => {
+      const { mapViewRef } = renderMapView();
+      const pixelPoint: PixelPoint = [100, 200];
+      const result = await mapViewRef.current.unproject(pixelPoint);
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.unproject,
+      ).toHaveBeenCalledWith(expect.any(Number), pixelPoint);
+      expect(result).toEqual(CENTER);
+    });
+
+    describe("queryRenderedFeatures", () => {
+      test("with pixel point", async () => {
+        const { mapViewRef } = renderMapView();
+        const pixelPoint: PixelPoint = [100, 200];
+        const options = {
+          layers: ["layer1", "layer2"],
+          filter: ["==", "type", "Point"] as const,
+        };
+
+        await mapViewRef.current.queryRenderedFeatures(pixelPoint, options);
+
+        expect(
+          mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithPoint,
+        ).toHaveBeenCalledWith(
+          expect.any(Number),
+          pixelPoint,
+          options.layers,
+          expect.any(Array),
+        );
+      });
+
+      test("with pixel bounds", async () => {
+        const { mapViewRef } = renderMapView();
+        const pixelPointBounds: PixelPointBounds = [
+          [100, 100],
+          [400, 400],
+        ] as const;
+        const options = {
+          layers: ["layer1"],
+          filter: ["==", "type", "Polygon"] as const,
+        };
+
+        await mapViewRef.current.queryRenderedFeatures(
+          pixelPointBounds,
+          options,
+        );
+
+        expect(
+          mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithBounds,
+        ).toHaveBeenCalledWith(
+          expect.any(Number),
+          pixelPointBounds,
+          options.layers,
+          expect.any(Array),
+        );
+      });
+
+      test("with no bounds (whole viewport)", async () => {
+        const { mapViewRef } = renderMapView();
+        const options = {
+          layers: ["layer1"],
+        };
+
+        await mapViewRef.current.queryRenderedFeatures(options);
+
+        expect(
+          mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithBounds,
+        ).toHaveBeenCalledWith(expect.any(Number), null, options.layers, []);
+      });
+
+      test("with no options", async () => {
+        const { mapViewRef } = renderMapView();
+
+        await mapViewRef.current.queryRenderedFeatures();
+
+        expect(
+          mockNativeModules.MLRNMapViewModule.queryRenderedFeaturesWithBounds,
+        ).toHaveBeenCalledWith(expect.any(Number), null, [], []);
+      });
+    });
+
+    test("takeSnap with writeToDisk=false", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.takeSnap(false);
+
+      expect(mockNativeModules.MLRNMapViewModule.takeSnap).toHaveBeenCalledWith(
+        expect.any(Number),
+        false,
+      );
+      expect(result).toBe("file://snapshot.png");
+    });
+
+    test("takeSnap with writeToDisk=true", async () => {
+      const { mapViewRef } = renderMapView();
+      const result = await mapViewRef.current.takeSnap(true);
+
+      expect(mockNativeModules.MLRNMapViewModule.takeSnap).toHaveBeenCalledWith(
+        expect.any(Number),
+        true,
+      );
+      expect(result).toBe("file://snapshot.png");
+    });
+
+    test("setSourceVisibility", async () => {
+      const { mapViewRef } = renderMapView();
+      await mapViewRef.current.setSourceVisibility(
+        false,
+        "composite",
+        "building",
+      );
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.setSourceVisibility,
+      ).toHaveBeenCalledWith(
+        expect.any(Number),
+        false,
+        "composite",
+        "building",
+      );
+    });
+
+    test("setSourceVisibility without sourceLayer", async () => {
+      const { mapViewRef } = renderMapView();
+      await mapViewRef.current.setSourceVisibility(true, "my-source");
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.setSourceVisibility,
+      ).toHaveBeenCalledWith(expect.any(Number), true, "my-source", null);
+    });
+
+    test("showAttribution", async () => {
+      const { mapViewRef } = renderMapView();
+      await mapViewRef.current.showAttribution();
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.showAttribution,
+      ).toHaveBeenCalledWith(expect.any(Number));
+    });
   });
 });

--- a/src/components/camera/Camera.tsx
+++ b/src/components/camera/Camera.tsx
@@ -15,7 +15,7 @@ import {
 import NativeCameraComponent from "./CameraNativeComponent";
 import NativeCameraModule from "./NativeCameraModule";
 import { type BaseProps } from "../../types/BaseProps";
-import type { Bounds } from "../../types/Bounds";
+import type { LngLatBounds } from "../../types/LngLatBounds";
 import type { ViewPadding } from "../../types/ViewPadding";
 
 export interface CameraOptions {
@@ -55,15 +55,17 @@ export interface CameraAnimationOptions {
 }
 
 export interface CameraCenterOptions {
-  longitude: number;
-  latitude: number;
+  /**
+   * Geographic center coordinates of the map
+   */
+  center: [longitude: number, latitude: number];
 }
 
 export interface CameraBoundsOptions {
   /**
    * The corners of a box around which the map should bound.
    */
-  bounds: Bounds;
+  bounds: LngLatBounds;
 }
 
 export type CameraCenterStop = CameraOptions &
@@ -77,8 +79,7 @@ export type CameraBoundsStop = CameraOptions &
 export type CameraStop =
   | (CameraOptions &
       CameraAnimationOptions & {
-        longitude?: never;
-        latitude?: never;
+        center?: never;
         bounds?: never;
       })
   | CameraCenterStop
@@ -86,8 +87,7 @@ export type CameraStop =
 
 export type InitialViewState =
   | (CameraOptions & {
-      longitude?: never;
-      latitude?: never;
+      center?: never;
       bounds?: never;
     })
   | (CameraOptions & CameraCenterOptions)
@@ -95,7 +95,7 @@ export type InitialViewState =
 
 export interface CameraRef {
   /**
-   * Map camera will move to new coordinate at the same zoom level
+   * Map camera will move to new coordinates at the same zoom level
    *
    * @example
    * cameraRef.current?.easeTo([lng, lat], 200) // eases camera to new location based on duration
@@ -104,10 +104,10 @@ export interface CameraRef {
    *  @param options.center Coordinates that map camera will move too
    *  @param options.duration Duration of camera animation
    */
-  jumpTo(options: { center: CameraCenterOptions } & CameraOptions): void;
+  jumpTo(options: CameraCenterOptions & CameraOptions): void;
 
   /**
-   * Map camera will move to new coordinate at the same zoom level
+   * Map camera will move to new coordinates at the same zoom level
    *
    * @example
    * cameraRef.current?.easeTo([lng, lat], 200) // eases camera to new location based on duration
@@ -117,8 +117,7 @@ export interface CameraRef {
    *  @param options.duration Duration of camera animation
    */
   easeTo(
-    options: { center: CameraCenterOptions } & CameraOptions &
-      CameraAnimationOptions,
+    options: CameraCenterOptions & CameraOptions & CameraAnimationOptions,
   ): void;
 
   /**
@@ -132,8 +131,7 @@ export interface CameraRef {
    *  @param options.duration Duration of camera animation
    */
   flyTo(
-    options: { center: CameraCenterOptions } & CameraOptions &
-      CameraAnimationOptions,
+    options: CameraCenterOptions & CameraOptions & CameraAnimationOptions,
   ): void;
 
   /**
@@ -149,7 +147,7 @@ export interface CameraRef {
    * @param options.duration Duration of camera animation
    */
   fitBounds(
-    bounds: Bounds,
+    bounds: LngLatBounds,
     options?: CameraOptions & CameraAnimationOptions,
   ): void;
 
@@ -214,7 +212,7 @@ export type CameraProps = BaseProps &
     /**
      * Restrict map panning so that the center is within these bounds
      */
-    maxBounds?: Bounds;
+    maxBounds?: LngLatBounds;
 
     /**
      * The mode used to track the user location on the map:
@@ -272,21 +270,21 @@ export const Camera = memo(
         setStop,
 
         jumpTo: ({ center, ...options }) =>
-          setStop({ ...options, ...center, duration: 0, easing: undefined }),
+          setStop({ ...options, center, duration: 0, easing: undefined }),
 
-        easeTo: ({ center, easing = "ease", duration = 500, ...options }) =>
-          setStop({ ...options, ...center, easing, duration }),
+        easeTo: ({ center, duration = 500, easing = "ease", ...options }) =>
+          setStop({ ...options, center, duration, easing }),
 
-        flyTo: ({ center, easing = "fly", duration = 2000, ...options }) =>
-          setStop({ ...options, ...center, easing, duration }),
+        flyTo: ({ center, duration = 2000, easing = "fly", ...options }) =>
+          setStop({ ...options, center, duration, easing }),
 
         fitBounds: (
           bounds,
-          { easing = "fly", duration = 2000, ...options } = {},
-        ) => setStop({ ...options, bounds, easing, duration }),
+          { duration = 2000, easing = "fly", ...options } = {},
+        ) => setStop({ ...options, bounds, duration, easing }),
 
-        zoomTo: (zoom, { easing = "ease", duration = 500, ...options } = {}) =>
-          setStop({ ...options, zoom, easing, duration }),
+        zoomTo: (zoom, { duration = 500, easing = "ease", ...options } = {}) =>
+          setStop({ ...options, zoom, duration, easing }),
       }));
 
       return (

--- a/src/components/camera/CameraNativeComponent.ts
+++ b/src/components/camera/CameraNativeComponent.ts
@@ -16,8 +16,7 @@ type NativeViewPadding = {
 };
 
 type NativeViewState = {
-  longitude?: CodegenTypes.WithDefault<CodegenTypes.Double, -360>;
-  latitude?: CodegenTypes.WithDefault<CodegenTypes.Double, -360>;
+  center?: CodegenTypes.Double[];
 
   bounds?: CodegenTypes.Double[];
 

--- a/src/components/camera/NativeCameraModule.ts
+++ b/src/components/camera/NativeCameraModule.ts
@@ -13,8 +13,7 @@ type NativeViewPadding = {
 };
 
 type NativeViewState = {
-  longitude?: CodegenTypes.WithDefault<CodegenTypes.Double, -360>;
-  latitude?: CodegenTypes.WithDefault<CodegenTypes.Double, -360>;
+  center?: CodegenTypes.Double[];
 
   bounds?: CodegenTypes.Double[];
 

--- a/src/components/map-view/MapView.tsx
+++ b/src/components/map-view/MapView.tsx
@@ -530,47 +530,42 @@ export const MapView = memo(
         ) => {
           if (
             pixelPointOrPixelPointBoundsOrOptions &&
-            Array.isArray(pixelPointOrPixelPointBoundsOrOptions)
+            Array.isArray(pixelPointOrPixelPointBoundsOrOptions) &&
+            ((value: PixelPoint | PixelPointBounds): value is PixelPoint =>
+              typeof value[0] === "number" && typeof value[1] === "number")(
+              pixelPointOrPixelPointBoundsOrOptions,
+            )
           ) {
-            if (
-              ((value: PixelPoint | PixelPointBounds): value is PixelPoint =>
-                typeof value[0] === "number" && typeof value[1] === "number")(
-                pixelPointOrPixelPointBoundsOrOptions,
-              )
-            ) {
-              return await NativeMapViewModule.queryRenderedFeaturesWithPoint(
-                findNodeHandle(nativeRef.current),
-                pixelPointOrPixelPointBoundsOrOptions,
-                options?.layers ?? [],
-                getFilter(options?.filter),
-              );
-            } else if (
-              ((
-                value: PixelPoint | PixelPointBounds,
-              ): value is PixelPointBounds =>
-                Array.isArray(value[0]) && Array.isArray(value[1]))(
-                pixelPointOrPixelPointBoundsOrOptions,
-              )
-            ) {
-              return await NativeMapViewModule.queryRenderedFeaturesWithBounds(
-                findNodeHandle(nativeRef.current),
-                pixelPointOrPixelPointBoundsOrOptions,
-                options?.layers ?? [],
-                getFilter(options?.filter),
-              );
-            }
-
-            throw new Error(
-              "Invalid PixelPoint or PixelPointBounds used with queryRenderedFeatures",
+            return await NativeMapViewModule.queryRenderedFeaturesWithPoint(
+              findNodeHandle(nativeRef.current),
+              pixelPointOrPixelPointBoundsOrOptions,
+              options?.layers ?? [],
+              getFilter(options?.filter),
+            );
+          } else if (
+            pixelPointOrPixelPointBoundsOrOptions &&
+            Array.isArray(pixelPointOrPixelPointBoundsOrOptions) &&
+            ((
+              value: PixelPoint | PixelPointBounds,
+            ): value is PixelPointBounds =>
+              Array.isArray(value[0]) && Array.isArray(value[1]))(
+              pixelPointOrPixelPointBoundsOrOptions,
+            )
+          ) {
+            return await NativeMapViewModule.queryRenderedFeaturesWithBounds(
+              findNodeHandle(nativeRef.current),
+              pixelPointOrPixelPointBoundsOrOptions,
+              options?.layers ?? [],
+              getFilter(options?.filter),
+            );
+          } else {
+            return await NativeMapViewModule.queryRenderedFeaturesWithBounds(
+              findNodeHandle(nativeRef.current),
+              null,
+              pixelPointOrPixelPointBoundsOrOptions?.layers ?? [],
+              getFilter(pixelPointOrPixelPointBoundsOrOptions?.filter),
             );
           }
-
-          return await NativeMapViewModule.queryRenderedFeaturesWithBounds(
-            findNodeHandle(nativeRef.current),
-            null,
-            pixelPointOrPixelPointBoundsOrOptions?.layers ?? [],
-            getFilter(pixelPointOrPixelPointBoundsOrOptions?.filter),
-          );
         },
 
         takeSnap: (writeToDisk = false) =>

--- a/src/components/map-view/MapView.tsx
+++ b/src/components/map-view/MapView.tsx
@@ -480,7 +480,7 @@ export interface MapViewProps extends BaseProps {
  */
 export const MapView = memo(
   forwardRef<MapViewRef, MapViewProps>(
-    ({ androidView = "surface", style, testID, ...props }, ref) => {
+    ({ androidView = "surface", style, ...props }, ref) => {
       const [isReady, setIsReady] = useState(false);
 
       const nativeRef = useRef<
@@ -635,7 +635,7 @@ export const MapView = memo(
         <View
           onLayout={() => setIsReady(true)}
           style={style ?? styles.flex1}
-          testID={mapView ? undefined : testID}
+          testID={nativeProps.testID ? `${nativeProps.testID}View` : undefined}
         >
           {mapView}
         </View>

--- a/src/components/map-view/MapView.tsx
+++ b/src/components/map-view/MapView.tsx
@@ -271,7 +271,7 @@ export interface MapViewRef {
   showAttribution(): Promise<void>;
 }
 
-interface MapViewProps extends BaseProps {
+export interface MapViewProps extends BaseProps {
   children?: ReactNode;
 
   /**

--- a/src/components/map-view/MapView.tsx
+++ b/src/components/map-view/MapView.tsx
@@ -112,7 +112,7 @@ export interface MapViewRef {
    *
    * @return Current center coordinates of the map
    */
-  getCenter(): Promise<ViewState["center"]>;
+  getCenter(): Promise<LngLat>;
 
   /**
    * Returns the current zoom level of the map
@@ -122,7 +122,7 @@ export interface MapViewRef {
    *
    * @return Current zoom level of the map
    */
-  getZoom(): Promise<ViewState["zoom"]>;
+  getZoom(): Promise<number>;
 
   /**
    * Returns the current bearing of the map
@@ -132,7 +132,7 @@ export interface MapViewRef {
    *
    * @return Current bearing of the map
    */
-  getBearing(): Promise<ViewState["bearing"]>;
+  getBearing(): Promise<number>;
 
   /**
    * Returns the current pitch of the map
@@ -142,7 +142,7 @@ export interface MapViewRef {
    *
    * @return Current pitch of the map
    */
-  getPitch(): Promise<ViewState["pitch"]>;
+  getPitch(): Promise<number>;
 
   /**
    * Returns the current bounds of the map
@@ -152,7 +152,7 @@ export interface MapViewRef {
    *
    * @return Current bounds of the map
    */
-  getBounds(): Promise<ViewState["bounds"]>;
+  getBounds(): Promise<LngLatBounds>;
 
   /**
    * Returns the current view state of the map
@@ -179,7 +179,7 @@ export interface MapViewRef {
    * Converts a pixel point of the view to geographic coordinates.
    *
    * @example
-   * await mapViewRef.current?.getCoordinateFromView([100, 100]);
+   * await mapViewRef.current?.getCoordinateFromView([280, 640]);
    *
    * @param point Pixel point
    * @return Geographic coordinate
@@ -265,8 +265,9 @@ export interface MapViewRef {
   ): Promise<void>;
 
   /**
-   * Show the attribution action sheet, can be used to implement a
-   * custom attribution button
+   * Show the attribution dialog
+   *
+   * Can be used to implement a custom attribution button.
    */
   showAttribution(): Promise<void>;
 }

--- a/src/components/map-view/MapViewNativeComponent.ts
+++ b/src/components/map-view/MapViewNativeComponent.ts
@@ -24,15 +24,16 @@ type NativeOrnamentViewPosition = {
 };
 
 type NativePressEvent = {
-  longitude: CodegenTypes.Double;
-  latitude: CodegenTypes.Double;
-  locationX: CodegenTypes.Double;
-  locationY: CodegenTypes.Double;
+  lngLat: UnsafeMixed<
+    [longitude: CodegenTypes.Double, latitude: CodegenTypes.Double]
+  >;
+  point: UnsafeMixed<[x: CodegenTypes.Double, y: CodegenTypes.Double]>;
 };
 
 type NativeViewStateEvent = {
-  longitude: CodegenTypes.Double;
-  latitude: CodegenTypes.Double;
+  center: UnsafeMixed<
+    [longitude: CodegenTypes.Double, latitude: CodegenTypes.Double]
+  >;
   zoom: CodegenTypes.Double;
   bearing: CodegenTypes.Double;
   pitch: CodegenTypes.Double;

--- a/src/components/map-view/NativeMapViewModule.ts
+++ b/src/components/map-view/NativeMapViewModule.ts
@@ -5,8 +5,7 @@ import {
 } from "react-native";
 
 type NativeViewState = {
-  longitude: CodegenTypes.Double;
-  latitude: CodegenTypes.Double;
+  center: CodegenTypes.Double[];
   zoom: CodegenTypes.Double;
   bearing: CodegenTypes.Double;
   pitch: CodegenTypes.Double;
@@ -14,10 +13,9 @@ type NativeViewState = {
 };
 
 export interface Spec extends TurboModule {
-  getCenter: (reactTag: CodegenTypes.Int32) => Promise<{
-    longitude: CodegenTypes.Double;
-    latitude: CodegenTypes.Double;
-  }>;
+  getCenter: (
+    reactTag: CodegenTypes.Int32,
+  ) => Promise<[longitude: CodegenTypes.Double, latitude: CodegenTypes.Double]>;
 
   getZoom: (reactTag: CodegenTypes.Int32) => Promise<CodegenTypes.Double>;
 
@@ -25,45 +23,42 @@ export interface Spec extends TurboModule {
 
   getPitch: (reactTag: CodegenTypes.Int32) => Promise<CodegenTypes.Double>;
 
-  getBounds: (reactTag: CodegenTypes.Int32) => Promise<CodegenTypes.Double[]>;
+  getBounds: (
+    reactTag: CodegenTypes.Int32,
+  ) => Promise<
+    [
+      west: CodegenTypes.Double,
+      south: CodegenTypes.Double,
+      east: CodegenTypes.Double,
+      north: CodegenTypes.Double,
+    ]
+  >;
 
   getViewState: (reactTag: CodegenTypes.Int32) => Promise<NativeViewState>;
 
   project: (
     reactTag: CodegenTypes.Int32,
-    coordinate: {
-      longitude: CodegenTypes.Double;
-      latitude: CodegenTypes.Double;
-    },
-  ) => Promise<{
-    locationX: CodegenTypes.Double;
-    locationY: CodegenTypes.Double;
-  }>;
+    lngLat: CodegenTypes.Double[],
+  ) => Promise<[x: CodegenTypes.Double, y: CodegenTypes.Double]>;
 
   unproject: (
     reactTag: CodegenTypes.Int32,
-    point: { locationX: CodegenTypes.Double; locationY: CodegenTypes.Double },
-  ) => Promise<{
-    longitude: CodegenTypes.Double;
-    latitude: CodegenTypes.Double;
-  }>;
+    pixelPoint: CodegenTypes.Double[],
+  ) => Promise<[longitude: CodegenTypes.Double, latitude: CodegenTypes.Double]>;
 
-  queryRenderedFeaturesWithCoordinate: (
+  queryRenderedFeaturesWithPoint: (
     reactTag: CodegenTypes.Int32,
-    coordinate: {
-      longitude: CodegenTypes.Double;
-      latitude: CodegenTypes.Double;
-    },
+    pixelPoint: CodegenTypes.Double[],
     layers: string[],
     filter: string[],
-  ) => Promise<object>;
+  ) => Promise<GeoJSON.Feature[]>;
 
   queryRenderedFeaturesWithBounds: (
     reactTag: CodegenTypes.Int32,
-    bounds: CodegenTypes.Double[],
+    pixelPointBounds: CodegenTypes.Double[][] | null,
     layers: string[],
     filter: string[],
-  ) => Promise<object>;
+  ) => Promise<GeoJSON.Feature[]>;
 
   setSourceVisibility: (
     reactTag: CodegenTypes.Int32,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,8 @@ export { OfflineCreatePackOptions } from "./modules/offline/OfflineCreatePackOpt
 export { SnapshotManager } from "./modules/snapshot/SnapshotManager";
 export type { SnapshotInputOptions } from "./modules/snapshot/SnapshotOptions";
 
-export type { Bounds } from "./types/Bounds";
+export type { LngLat } from "./types/LngLat";
+export type { LngLatBounds } from "./types/LngLatBounds";
 export type {
   FillLayerStyle,
   LineLayerStyle,
@@ -76,6 +77,8 @@ export type {
   LightLayerStyle,
   Expression,
 } from "./types/MapLibreRNStyles";
+export type { PixelPoint } from "./types/PixelPoint";
+export type { PixelPointBounds } from "./types/PixelPointBounds";
 export type { PressEvent, PressEventWithFeatures } from "./types/PressEvent";
 export type { ViewPadding } from "./types/ViewPadding";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 export * from "./MLRNModule";
 
 export {
+  Camera,
+  type CameraProps,
+  type CameraRef,
   type CameraOptions,
   type CameraEasing,
   type CameraAnimationOptions,
@@ -10,15 +13,13 @@ export {
   type CameraBoundsStop,
   type CameraStop,
   type InitialViewState,
-  type CameraRef,
   type TrackUserLocation,
   type TrackUserLocationChangeEvent,
-  type CameraProps,
-  Camera,
 } from "./components/camera/Camera";
 
 export {
   MapView,
+  type MapViewProps,
   type MapViewRef,
   type ViewState,
   type ViewStateChangeEvent,

--- a/src/types/Bounds.ts
+++ b/src/types/Bounds.ts
@@ -1,1 +1,0 @@
-export type Bounds = [west: number, south: number, east: number, north: number];

--- a/src/types/LngLat.ts
+++ b/src/types/LngLat.ts
@@ -1,0 +1,4 @@
+/**
+ * Geographic coordinates
+ */
+export type LngLat = [longitude: number, latitude: number];

--- a/src/types/LngLatBounds.ts
+++ b/src/types/LngLatBounds.ts
@@ -1,0 +1,11 @@
+/**
+ * Represents bounds in geographic coordinates
+ *
+ * Uses order of south-west and north-east corners in flat style per GeoJSON RFC.
+ */
+export type LngLatBounds = [
+  west: number,
+  south: number,
+  east: number,
+  north: number,
+];

--- a/src/types/PixelPoint.ts
+++ b/src/types/PixelPoint.ts
@@ -1,0 +1,4 @@
+/**
+ * Pixel coordinates
+ */
+export type PixelPoint = [x: number, y: number];

--- a/src/types/PixelPointBounds.ts
+++ b/src/types/PixelPointBounds.ts
@@ -1,0 +1,9 @@
+/**
+ * Bounds in pixel coordinates
+ *
+ * Uses common order of top-left and bottom-right corners.
+ */
+export type PixelPointBounds = [
+  topLeft: [left: number, top: number],
+  bottomRight: [right: number, bottom: number],
+];

--- a/src/types/PressEvent.ts
+++ b/src/types/PressEvent.ts
@@ -1,17 +1,16 @@
+import type { LngLat } from "./LngLat";
+import type { PixelPoint } from "./PixelPoint";
+
 export interface PressEvent {
-  longitude: number;
-
-  latitude: number;
+  /**
+   * Geographic coordinates of the touch event
+   */
+  lngLat: LngLat;
 
   /**
-   * Touch origin X coordinate inside touchable area (relative to the element).
+   * Pixel point of the touch event within the elements' viewport
    */
-  locationX: number;
-
-  /**
-   * Touch origin Y coordinate inside touchable area (relative to the element).
-   */
-  locationY: number;
+  point: PixelPoint;
 }
 
 export interface PressEventWithFeatures extends PressEvent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,7 +4455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect-utils@npm:29.7.0, @jest/expect-utils@npm:^29.7.0":
+"@jest/expect-utils@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/expect-utils@npm:29.7.0"
   dependencies:
@@ -4842,7 +4842,7 @@ __metadata:
   resolution: "@maplibre-react-native/examples@workspace:examples/shared"
   dependencies:
     "@babel/core": "npm:^7.28.4"
-    "@jest/expect-utils": "npm:29.7.0"
+    "@jest/expect-utils": "npm:^29.7.0"
     "@mapbox/geo-viewport": "npm:^0.5.0"
     "@maplibre/maplibre-react-native": "workspace:*"
     "@react-native-masked-view/masked-view": "npm:0.3.2"
@@ -4855,7 +4855,7 @@ __metadata:
     "@turf/helpers": "npm:^7.1.0"
     "@types/mapbox__geo-viewport": "npm:^0.5.3"
     "@types/react": "npm:^19.1.13"
-    jest-diff: "npm:29.7.0"
+    jest-diff: "npm:^29.7.0"
     moment: "npm:^2.30.1"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
@@ -4864,7 +4864,7 @@ __metadata:
     react-native-reanimated: "npm:~3.19.1"
     react-native-safe-area-context: "npm:5.6.1"
     react-native-screens: "npm:~4.16.0"
-    zod: "npm:4.1.13"
+    zod: "npm:^4.1.13"
   peerDependencies:
     "@react-native-masked-view/masked-view": "*"
     react: "*"
@@ -15944,18 +15944,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:29.7.0, jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-diff@npm:29.7.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    diff-sequences: "npm:^29.6.3"
-    jest-get-type: "npm:^29.6.3"
-    pretty-format: "npm:^29.7.0"
-  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
-  languageName: node
-  linkType: hard
-
 "jest-diff@npm:30.0.5":
   version: 30.0.5
   resolution: "jest-diff@npm:30.0.5"
@@ -15965,6 +15953,18 @@ __metadata:
     chalk: "npm:^4.1.2"
     pretty-format: "npm:30.0.5"
   checksum: 10c0/b218ced37b7676f578ea866762f04caa74901bdcf3f593872aa9a4991a586302651a1d16bb0386772adacc7580a452ec621359af75d733c0b50ea947fe1881d3
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:^29.6.3"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
   languageName: node
   linkType: hard
 
@@ -27314,17 +27314,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:4.1.13":
-  version: 4.1.13
-  resolution: "zod@npm:4.1.13"
-  checksum: 10c0/d7e74e82dba81a91ffc3239cd85bc034abe193a28f7087a94ab258a3e48e9a7ca4141920cac979a0d781495b48fc547777394149f26be04c3dc642f58bbc3941
-  languageName: node
-  linkType: hard
-
 "zod@npm:^3.25.76":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.1.13":
+  version: 4.1.13
+  resolution: "zod@npm:4.1.13"
+  checksum: 10c0/d7e74e82dba81a91ffc3239cd85bc034abe193a28f7087a94ab258a3e48e9a7ca4141920cac979a0d781495b48fc547777394149f26be04c3dc642f58bbc3941
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,29 +419,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.27.4":
-  version: 7.27.7
-  resolution: "@babel/core@npm:7.27.7"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.2.0"
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.27.5"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-module-transforms": "npm:^7.27.3"
-    "@babel/helpers": "npm:^7.27.6"
-    "@babel/parser": "npm:^7.27.7"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.27.7"
-    "@babel/types": "npm:^7.27.7"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/02c0cd475821c5333d5ee5eb9a0565af1a38234b37859ae09c4c95d7171bbc11a23a6f733c31b3cb12dc523311bdc8f7f9d705136f33eeb6704b7fbd6e6468ca
-  languageName: node
-  linkType: hard
-
 "@babel/core@npm:^7.28.0, @babel/core@npm:^7.28.4":
   version: 7.28.4
   resolution: "@babel/core@npm:7.28.4"
@@ -514,19 +491,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jsesc: "npm:^3.0.2"
   checksum: 10c0/341622e17c61d008fc746b655ab95ef7febb543df8efb4148f57cf06e60ade1abe091ed7d6811df17b064d04d64f69bb7f35ab0654137116d55c54a73145a61a
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.27.5":
-  version: 7.27.5
-  resolution: "@babel/generator@npm:7.27.5"
-  dependencies:
-    "@babel/parser": "npm:^7.27.5"
-    "@babel/types": "npm:^7.27.3"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^3.0.2"
-  checksum: 10c0/8f649ef4cd81765c832bb11de4d6064b035ffebdecde668ba7abee68a7b0bce5c9feabb5dc5bb8aeba5bd9e5c2afa3899d852d2bd9ca77a711ba8c8379f416f0
   languageName: node
   linkType: hard
 
@@ -896,16 +860,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.27.6":
-  version: 7.27.6
-  resolution: "@babel/helpers@npm:7.27.6"
-  dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.6"
-  checksum: 10c0/448bac96ef8b0f21f2294a826df9de6bf4026fd023f8a6bb6c782fe3e61946801ca24381490b8e58d861fee75cd695a1882921afbf1f53b0275ee68c938bd6d3
-  languageName: node
-  linkType: hard
-
 "@babel/helpers@npm:^7.28.4":
   version: 7.28.4
   resolution: "@babel/helpers@npm:7.28.4"
@@ -969,28 +923,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/d1bf17e7508585235e2a76594ba81828e48851877112bb8abbecd7161a31fb66654e993e458ddaedb18a3d5fa31970e5f3feca5ae2900f51e6d8d3d35da70dbf
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.27.5":
-  version: 7.27.5
-  resolution: "@babel/parser@npm:7.27.5"
-  dependencies:
-    "@babel/types": "npm:^7.27.3"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/f7faaebf21cc1f25d9ca8ac02c447ed38ef3460ea95be7ea760916dcf529476340d72a5a6010c6641d9ed9d12ad827c8424840277ec2295c5b082ba0f291220a
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.27.7":
-  version: 7.27.7
-  resolution: "@babel/parser@npm:7.27.7"
-  dependencies:
-    "@babel/types": "npm:^7.27.7"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/f6202faeb873f0b3083022e50a5046fe07266d337c0a3bd80a491f8435ba6d9e383d49725e3dcd666b3b52c0dccb4e0f1f1004915762345f7eeed5ba54ea9fd2
   languageName: node
   linkType: hard
 
@@ -1251,17 +1183,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-jsx@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/bc5afe6a458d5f0492c02a54ad98c5756a0c13bd6d20609aae65acd560a9e141b0876da5f358dce34ea136f271c1016df58b461184d7ae9c4321e0f98588bc84
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
@@ -1358,17 +1279,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/5192ebe11bd46aea68b7a60fd9555465c59af7e279e71126788e59121b86e00b505816685ab4782abe159232b0f73854e804b54449820b0d950b397ee158caa2
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-typescript@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-typescript@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/11589b4c89c66ef02d57bf56c6246267851ec0c361f58929327dc3e070b0dab644be625bbe7fb4c4df30c3634bfdfe31244e1f517be397d2def1487dbbe3c37d
   languageName: node
   linkType: hard
 
@@ -2377,21 +2287,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.27.7":
-  version: 7.27.7
-  resolution: "@babel/traverse@npm:7.27.7"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.27.5"
-    "@babel/parser": "npm:^7.27.7"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.7"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10c0/941fecd0248546f059d58230590a2765d128ef072c8521c9e0bcf6037abf28a0ea4736003d0d695513128d07fe00a7bc57acaada2ed905941d44619b9f49cf0c
-  languageName: node
-  linkType: hard
-
 "@babel/traverse@npm:^7.28.0, @babel/traverse@npm:^7.28.4":
   version: 7.28.4
   resolution: "@babel/traverse@npm:7.28.4"
@@ -2469,16 +2364,6 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: 10c0/bafdfc98e722a6b91a783b6f24388f478fd775f0c0652e92220e08be2cc33e02d42088542f1953ac5e5ece2ac052172b3dadedf12bec9aae57899e92fb9a9757
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.27.6, @babel/types@npm:^7.27.7":
-  version: 7.27.7
-  resolution: "@babel/types@npm:7.27.7"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-  checksum: 10c0/1d1dcb5fa7cfba2b4034a3ab99ba17049bfc4af9e170935575246cdb1cee68b04329a0111506d9ae83fb917c47dbd4394a6db5e32fbd041b7834ffbb17ca086b
   languageName: node
   linkType: hard
 
@@ -3662,34 +3547,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@emnapi/core@npm:1.4.3"
-  dependencies:
-    "@emnapi/wasi-threads": "npm:1.0.2"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/e30101d16d37ef3283538a35cad60e22095aff2403fb9226a35330b932eb6740b81364d525537a94eb4fb51355e48ae9b10d779c0dd1cdcd55d71461fe4b45c7
-  languageName: node
-  linkType: hard
-
-"@emnapi/runtime@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@emnapi/runtime@npm:1.4.3"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/3b7ab72d21cb4e034f07df80165265f85f445ef3f581d1bc87b67e5239428baa00200b68a7d5e37a0425c3a78320b541b07f76c5530f6f6f95336a6294ebf30b
-  languageName: node
-  linkType: hard
-
-"@emnapi/wasi-threads@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@emnapi/wasi-threads@npm:1.0.2"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/f0621b1fc715221bd2d8332c0ca922617bcd77cdb3050eae50a124eb8923c54fa425d23982dc8f29d505c8798a62d1049bace8b0686098ff9dd82270e06d772e
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/aix-ppc64@npm:0.25.0"
@@ -4515,20 +4372,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/console@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/console@npm:30.1.2"
-  dependencies:
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
-    jest-message-util: "npm:30.1.0"
-    jest-util: "npm:30.0.5"
-    slash: "npm:^3.0.0"
-  checksum: 10c0/108c8d891955f97ecfb8a687ce8e5ce2d0bcc59ef4b5400ae219fb5183f4b35a0dd1ba3429bbe9abe9a5134a8f8e1ce89f09f2e2758487028eb339406df58b05
-  languageName: node
-  linkType: hard
-
 "@jest/console@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/console@npm:29.7.0"
@@ -4543,44 +4386,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/core@npm:30.1.3":
-  version: 30.1.3
-  resolution: "@jest/core@npm:30.1.3"
+"@jest/core@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/core@npm:29.7.0"
   dependencies:
-    "@jest/console": "npm:30.1.2"
-    "@jest/pattern": "npm:30.0.1"
-    "@jest/reporters": "npm:30.1.3"
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/transform": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
+    "@jest/console": "npm:^29.7.0"
+    "@jest/reporters": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
     "@types/node": "npm:*"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
-    ci-info: "npm:^4.2.0"
-    exit-x: "npm:^0.2.2"
-    graceful-fs: "npm:^4.2.11"
-    jest-changed-files: "npm:30.0.5"
-    jest-config: "npm:30.1.3"
-    jest-haste-map: "npm:30.1.0"
-    jest-message-util: "npm:30.1.0"
-    jest-regex-util: "npm:30.0.1"
-    jest-resolve: "npm:30.1.3"
-    jest-resolve-dependencies: "npm:30.1.3"
-    jest-runner: "npm:30.1.3"
-    jest-runtime: "npm:30.1.3"
-    jest-snapshot: "npm:30.1.2"
-    jest-util: "npm:30.0.5"
-    jest-validate: "npm:30.1.0"
-    jest-watcher: "npm:30.1.3"
-    micromatch: "npm:^4.0.8"
-    pretty-format: "npm:30.0.5"
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    exit: "npm:^0.1.2"
+    graceful-fs: "npm:^4.2.9"
+    jest-changed-files: "npm:^29.7.0"
+    jest-config: "npm:^29.7.0"
+    jest-haste-map: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-regex-util: "npm:^29.6.3"
+    jest-resolve: "npm:^29.7.0"
+    jest-resolve-dependencies: "npm:^29.7.0"
+    jest-runner: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    jest-watcher: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    pretty-format: "npm:^29.7.0"
     slash: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.0"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 10c0/0f934a027b969daebe8e44ba3127a80c2ac1a65becc16b1f9d5a072718d950ce3c1910ce0675a98d5ef1777014e842b5bf6dd736fb9c6442a22ebfd326ae50c5
+  checksum: 10c0/934f7bf73190f029ac0f96662c85cd276ec460d407baf6b0dbaec2872e157db4d55a7ee0b1c43b18874602f662b37cb973dda469a4e6d88b4e4845b521adeeb2
   languageName: node
   linkType: hard
 
@@ -4600,18 +4443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/environment@npm:30.1.2"
-  dependencies:
-    "@jest/fake-timers": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    jest-mock: "npm:30.0.5"
-  checksum: 10c0/41ac75f75d37f76cf89d97df55da107972068e8e4d4fa230bef5119b0efcb8a9feaca405a776bcbe7207f9c162990d41894636c793d3a9f0b9708e7c8ef57c6e
-  languageName: node
-  linkType: hard
-
 "@jest/environment@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/environment@npm:29.7.0"
@@ -4624,31 +4455,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect-utils@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/expect-utils@npm:30.1.2"
-  dependencies:
-    "@jest/get-type": "npm:30.1.0"
-  checksum: 10c0/5b6c4d400ad0bd22960bd77750baf55b24bf1ebdc2cec328afe275967db76bf94f797ca4c9817cdb86bc7820b9219d3f493705f3fa94fe7720960e47805a8e1b
-  languageName: node
-  linkType: hard
-
-"@jest/expect-utils@npm:^29.7.0":
+"@jest/expect-utils@npm:29.7.0, @jest/expect-utils@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/expect-utils@npm:29.7.0"
   dependencies:
     jest-get-type: "npm:^29.6.3"
   checksum: 10c0/60b79d23a5358dc50d9510d726443316253ecda3a7fb8072e1526b3e0d3b14f066ee112db95699b7a43ad3f0b61b750c72e28a5a1cac361d7a2bb34747fa938a
-  languageName: node
-  linkType: hard
-
-"@jest/expect@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/expect@npm:30.1.2"
-  dependencies:
-    expect: "npm:30.1.2"
-    jest-snapshot: "npm:30.1.2"
-  checksum: 10c0/e441639d902f8a9e894e856b98378cf2b14b102c04df160203482087e06a1bdbb961beb5c021012946dfa72019594e7dd0456fb5a1572f1f4d8f16475b44b0b3
   languageName: node
   linkType: hard
 
@@ -4659,20 +4471,6 @@ __metadata:
     expect: "npm:^29.7.0"
     jest-snapshot: "npm:^29.7.0"
   checksum: 10c0/b41f193fb697d3ced134349250aed6ccea075e48c4f803159db102b826a4e473397c68c31118259868fd69a5cba70e97e1c26d2c2ff716ca39dc73a2ccec037e
-  languageName: node
-  linkType: hard
-
-"@jest/fake-timers@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/fake-timers@npm:30.1.2"
-  dependencies:
-    "@jest/types": "npm:30.0.5"
-    "@sinonjs/fake-timers": "npm:^13.0.0"
-    "@types/node": "npm:*"
-    jest-message-util: "npm:30.1.0"
-    jest-mock: "npm:30.0.5"
-    jest-util: "npm:30.0.5"
-  checksum: 10c0/043ac3b5d60041550d86be9f178caf6146a579fb7a6b10b497e9f8c46a9198c1c5f4a8a2177cd5a128e1fa4ba252dfcaa13b1975ef180fa941551efe126f4b61
   languageName: node
   linkType: hard
 
@@ -4697,26 +4495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/get-type@npm:30.1.0":
-  version: 30.1.0
-  resolution: "@jest/get-type@npm:30.1.0"
-  checksum: 10c0/3e65fd5015f551c51ec68fca31bbd25b466be0e8ee8075d9610fa1c686ea1e70a942a0effc7b10f4ea9a338c24337e1ad97ff69d3ebacc4681b7e3e80d1b24ac
-  languageName: node
-  linkType: hard
-
-"@jest/globals@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/globals@npm:30.1.2"
-  dependencies:
-    "@jest/environment": "npm:30.1.2"
-    "@jest/expect": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
-    jest-mock: "npm:30.0.5"
-  checksum: 10c0/f743e83d5be14bfff171b04fa59a1d624a6f7086e6472e83c8e6a5d156e91e2ac076a826063ef4dc3045df453108aed4f17baa888d74a0aeb71517ded0791cfd
-  languageName: node
-  linkType: hard
-
-"@jest/globals@npm:^29.2.1":
+"@jest/globals@npm:^29.2.1, @jest/globals@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/globals@npm:29.7.0"
   dependencies:
@@ -4728,49 +4507,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/pattern@npm:30.0.1":
-  version: 30.0.1
-  resolution: "@jest/pattern@npm:30.0.1"
-  dependencies:
-    "@types/node": "npm:*"
-    jest-regex-util: "npm:30.0.1"
-  checksum: 10c0/32c5a7bfb6c591f004dac0ed36d645002ed168971e4c89bd915d1577031672870032594767557b855c5bc330aa1e39a2f54bf150d2ee88a7a0886e9cb65318bc
-  languageName: node
-  linkType: hard
-
-"@jest/reporters@npm:30.1.3":
-  version: 30.1.3
-  resolution: "@jest/reporters@npm:30.1.3"
+"@jest/reporters@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/reporters@npm:29.7.0"
   dependencies:
     "@bcoe/v8-coverage": "npm:^0.2.3"
-    "@jest/console": "npm:30.1.2"
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/transform": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    "@jest/console": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@jridgewell/trace-mapping": "npm:^0.3.18"
     "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
-    collect-v8-coverage: "npm:^1.0.2"
-    exit-x: "npm:^0.2.2"
-    glob: "npm:^10.3.10"
-    graceful-fs: "npm:^4.2.11"
+    chalk: "npm:^4.0.0"
+    collect-v8-coverage: "npm:^1.0.0"
+    exit: "npm:^0.1.2"
+    glob: "npm:^7.1.3"
+    graceful-fs: "npm:^4.2.9"
     istanbul-lib-coverage: "npm:^3.0.0"
     istanbul-lib-instrument: "npm:^6.0.0"
     istanbul-lib-report: "npm:^3.0.0"
-    istanbul-lib-source-maps: "npm:^5.0.0"
+    istanbul-lib-source-maps: "npm:^4.0.0"
     istanbul-reports: "npm:^3.1.3"
-    jest-message-util: "npm:30.1.0"
-    jest-util: "npm:30.0.5"
-    jest-worker: "npm:30.1.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-worker: "npm:^29.7.0"
     slash: "npm:^3.0.0"
-    string-length: "npm:^4.0.2"
+    string-length: "npm:^4.0.1"
+    strip-ansi: "npm:^6.0.0"
     v8-to-istanbul: "npm:^9.0.1"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 10c0/2b027e775216804b4f3766105bd4eb3e8e31480f78cc9a409ae7d335cc21883f5bd063c66215c0bc18cbcdda98824d1b02e74593f6464caf8920f0804ce706bb
+  checksum: 10c0/a754402a799541c6e5aff2c8160562525e2a47e7d568f01ebfc4da66522de39cbb809bbb0a841c7052e4270d79214e70aec3c169e4eae42a03bc1a8a20cb9fa2
   languageName: node
   linkType: hard
 
@@ -4792,38 +4562,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/snapshot-utils@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/snapshot-utils@npm:30.1.2"
+"@jest/source-map@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/source-map@npm:29.6.3"
   dependencies:
-    "@jest/types": "npm:30.0.5"
-    chalk: "npm:^4.1.2"
-    graceful-fs: "npm:^4.2.11"
-    natural-compare: "npm:^1.4.0"
-  checksum: 10c0/bb5bbb3b3d0560ed1bf9439eb14280c80ead6534b7a985dbbfc656940ca140431f0719bdb7051df2a5fa897e7166f5c1902481dc57938fd6bb22b08ee7d6e09b
-  languageName: node
-  linkType: hard
-
-"@jest/source-map@npm:30.0.1":
-  version: 30.0.1
-  resolution: "@jest/source-map@npm:30.0.1"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    callsites: "npm:^3.1.0"
-    graceful-fs: "npm:^4.2.11"
-  checksum: 10c0/e7bda2786fc9f483d9dd7566c58c4bd948830997be862dfe80a3ae5550ff3f84753abb52e705d02ebe9db9f34ba7ebec4c2db11882048cdeef7a66f6332b3897
-  languageName: node
-  linkType: hard
-
-"@jest/test-result@npm:30.1.3":
-  version: 30.1.3
-  resolution: "@jest/test-result@npm:30.1.3"
-  dependencies:
-    "@jest/console": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
-    "@types/istanbul-lib-coverage": "npm:^2.0.6"
-    collect-v8-coverage: "npm:^1.0.2"
-  checksum: 10c0/610982f31d0c83d3bc9497cf4b56dacde3af6909b70dcbc986afb8e85c665061788b9d98f347412b8345cd6b2de6293c4fbde66a4bcbbf6fbb6de6a6905d8dde
+    "@jridgewell/trace-mapping": "npm:^0.3.18"
+    callsites: "npm:^3.0.0"
+    graceful-fs: "npm:^4.2.9"
+  checksum: 10c0/a2f177081830a2e8ad3f2e29e20b63bd40bade294880b595acf2fc09ec74b6a9dd98f126a2baa2bf4941acd89b13a4ade5351b3885c224107083a0059b60a219
   languageName: node
   linkType: hard
 
@@ -4839,38 +4585,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/test-sequencer@npm:30.1.3":
-  version: 30.1.3
-  resolution: "@jest/test-sequencer@npm:30.1.3"
+"@jest/test-sequencer@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-sequencer@npm:29.7.0"
   dependencies:
-    "@jest/test-result": "npm:30.1.3"
-    graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.1.0"
+    "@jest/test-result": "npm:^29.7.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
     slash: "npm:^3.0.0"
-  checksum: 10c0/ed9b24e3b37f5a6f3ae79b72fd0f241ddb422697c56b7fc49bf8b2ae3171ad466b6423a4965043ec224cdbac98c55009b585c0d79daa4ace288a2ed3ef3c38c0
-  languageName: node
-  linkType: hard
-
-"@jest/transform@npm:30.1.2":
-  version: 30.1.2
-  resolution: "@jest/transform@npm:30.1.2"
-  dependencies:
-    "@babel/core": "npm:^7.27.4"
-    "@jest/types": "npm:30.0.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    babel-plugin-istanbul: "npm:^7.0.0"
-    chalk: "npm:^4.1.2"
-    convert-source-map: "npm:^2.0.0"
-    fast-json-stable-stringify: "npm:^2.1.0"
-    graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.1.0"
-    jest-regex-util: "npm:30.0.1"
-    jest-util: "npm:30.0.5"
-    micromatch: "npm:^4.0.8"
-    pirates: "npm:^4.0.7"
-    slash: "npm:^3.0.0"
-    write-file-atomic: "npm:^5.0.1"
-  checksum: 10c0/b427614659a982515efcb52ac20c28c02cca133b4602549c205dda08222e5e9ed8807181d28e076e158b69fc9f8cc6a5f481e9a44c67f6fa6a64829458c5c9e3
+  checksum: 10c0/593a8c4272797bb5628984486080cbf57aed09c7cfdc0a634e8c06c38c6bef329c46c0016e84555ee55d1cd1f381518cf1890990ff845524c1123720c8c1481b
   languageName: node
   linkType: hard
 
@@ -4894,21 +4617,6 @@ __metadata:
     slash: "npm:^3.0.0"
     write-file-atomic: "npm:^4.0.2"
   checksum: 10c0/7f4a7f73dcf45dfdf280c7aa283cbac7b6e5a904813c3a93ead7e55873761fc20d5c4f0191d2019004fac6f55f061c82eb3249c2901164ad80e362e7a7ede5a6
-  languageName: node
-  linkType: hard
-
-"@jest/types@npm:30.0.5":
-  version: 30.0.5
-  resolution: "@jest/types@npm:30.0.5"
-  dependencies:
-    "@jest/pattern": "npm:30.0.1"
-    "@jest/schemas": "npm:30.0.5"
-    "@types/istanbul-lib-coverage": "npm:^2.0.6"
-    "@types/istanbul-reports": "npm:^3.0.4"
-    "@types/node": "npm:*"
-    "@types/yargs": "npm:^17.0.33"
-    chalk: "npm:^4.1.2"
-  checksum: 10c0/fd097a390e36edacbd2c92a8378ec0cd67abec5e234bab7a80aec6eb8625568052b0c32acf472388d04c4cf384b8fa2871d0d12a56b4b06eaea93f2c6df0ec6c
   languageName: node
   linkType: hard
 
@@ -4998,7 +4706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.23, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
   version: 0.3.25
   resolution: "@jridgewell/trace-mapping@npm:0.3.25"
   dependencies:
@@ -5134,6 +4842,7 @@ __metadata:
   resolution: "@maplibre-react-native/examples@workspace:examples/shared"
   dependencies:
     "@babel/core": "npm:^7.28.4"
+    "@jest/expect-utils": "npm:29.7.0"
     "@mapbox/geo-viewport": "npm:^0.5.0"
     "@maplibre/maplibre-react-native": "workspace:*"
     "@react-native-masked-view/masked-view": "npm:0.3.2"
@@ -5146,6 +4855,7 @@ __metadata:
     "@turf/helpers": "npm:^7.1.0"
     "@types/mapbox__geo-viewport": "npm:^0.5.3"
     "@types/react": "npm:^19.1.13"
+    jest-diff: "npm:29.7.0"
     moment: "npm:^2.30.1"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
@@ -5154,6 +4864,7 @@ __metadata:
     react-native-reanimated: "npm:~3.19.1"
     react-native-safe-area-context: "npm:5.6.1"
     react-native-screens: "npm:~4.16.0"
+    zod: "npm:4.1.13"
   peerDependencies:
     "@react-native-masked-view/masked-view": "*"
     react: "*"
@@ -5209,7 +4920,7 @@ __metadata:
     eslint: "npm:^8.57.1"
     eslint-config-universe: "npm:15.0.3"
     expo-module-scripts: "npm:^5.0.7"
-    jest: "npm:^30.1.3"
+    jest: "npm:^29.7.0"
     prettier: "npm:3.6.2"
     react: "npm:19.1.0"
     react-docgen: "npm:^8.0.1"
@@ -5290,17 +5001,6 @@ __metadata:
     "@types/react": ">=16"
     react: ">=16"
   checksum: 10c0/34ca98bc2a0f969894ea144dc5c8a5294690505458cd24965cd9be854d779c193ad9192bf9143c4c18438fafd1902e100d99067e045c69319288562d497558c6
-  languageName: node
-  linkType: hard
-
-"@napi-rs/wasm-runtime@npm:^0.2.11":
-  version: 0.2.11
-  resolution: "@napi-rs/wasm-runtime@npm:0.2.11"
-  dependencies:
-    "@emnapi/core": "npm:^1.4.3"
-    "@emnapi/runtime": "npm:^1.4.3"
-    "@tybys/wasm-util": "npm:^0.9.0"
-  checksum: 10c0/049bd14c58b99fbe0967b95e9921c5503df196b59be22948d2155f17652eb305cff6728efd8685338b855da7e476dd2551fbe3a313fc2d810938f0717478441e
   languageName: node
   linkType: hard
 
@@ -5749,13 +5449,6 @@ __metadata:
   version: 0.2.4
   resolution: "@pkgr/core@npm:0.2.4"
   checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
-  languageName: node
-  linkType: hard
-
-"@pkgr/core@npm:^0.2.4":
-  version: 0.2.7
-  resolution: "@pkgr/core@npm:0.2.7"
-  checksum: 10c0/951f5ebf2feb6e9dbc202d937f1a364d60f2bf0e3e53594251bcc1d9d2ed0df0a919c49ba162a9499fce73cf46ebe4d7959a8dfbac03511dbe79b69f5fedb804
   languageName: node
   linkType: hard
 
@@ -6627,15 +6320,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^13.0.0":
-  version: 13.0.5
-  resolution: "@sinonjs/fake-timers@npm:13.0.5"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-  checksum: 10c0/a707476efd523d2138ef6bba916c83c4a377a8372ef04fad87499458af9f01afc58f4f245c5fd062793d6d70587309330c6f96947b5bd5697961c18004dc3e26
-  languageName: node
-  linkType: hard
-
 "@sinonjs/fake-timers@npm:^15.0.0":
   version: 15.0.0
   resolution: "@sinonjs/fake-timers@npm:15.0.0"
@@ -7046,15 +6730,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@tybys/wasm-util@npm:0.9.0"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/f9fde5c554455019f33af6c8215f1a1435028803dc2a2825b077d812bed4209a1a64444a4ca0ce2ea7e1175c8d88e2f9173a36a33c199e8a5c671aa31de8242d
-  languageName: node
-  linkType: hard
-
 "@types/acorn@npm:^4.0.0":
   version: 4.0.6
   resolution: "@types/acorn@npm:4.0.6"
@@ -7363,7 +7038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 10c0/3948088654f3eeb45363f1db158354fb013b362dba2a5c2c18c559484d5eb9f6fd85b23d66c0a7c2fcfab7308d0a585b14dadaca6cc8bf89ebfdc7f8f5102fb7
@@ -7379,7 +7054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-reports@npm:^3.0.0, @types/istanbul-reports@npm:^3.0.4":
+"@types/istanbul-reports@npm:^3.0.0":
   version: 3.0.4
   resolution: "@types/istanbul-reports@npm:3.0.4"
   dependencies:
@@ -7678,7 +7353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stack-utils@npm:^2.0.0, @types/stack-utils@npm:^2.0.3":
+"@types/stack-utils@npm:^2.0.0":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
@@ -7729,7 +7404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.33, @types/yargs@npm:^17.0.8":
+"@types/yargs@npm:^17.0.8":
   version: 17.0.33
   resolution: "@types/yargs@npm:17.0.33"
   dependencies:
@@ -7868,141 +7543,6 @@ __metadata:
   version: 1.3.0
   resolution: "@ungap/structured-clone@npm:1.3.0"
   checksum: 10c0/0fc3097c2540ada1fc340ee56d58d96b5b536a2a0dab6e3ec17d4bfc8c4c86db345f61a375a8185f9da96f01c69678f836a2b57eeaa9e4b8eeafd26428e57b0a
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-android-arm-eabi@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-android-arm-eabi@npm:1.9.1"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-android-arm64@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-android-arm64@npm:1.9.1"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-darwin-arm64@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.9.1"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-darwin-x64@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.9.1"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-freebsd-x64@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.9.1"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.9.1"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.9.1"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-arm64-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.9.1"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-arm64-musl@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.9.1"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.9.1"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-riscv64-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-riscv64-gnu@npm:1.9.1"
-  conditions: os=linux & cpu=riscv64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-riscv64-musl@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-riscv64-musl@npm:1.9.1"
-  conditions: os=linux & cpu=riscv64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-s390x-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.9.1"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-x64-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.9.1"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-linux-x64-musl@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.9.1"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-wasm32-wasi@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.9.1"
-  dependencies:
-    "@napi-rs/wasm-runtime": "npm:^0.2.11"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-win32-arm64-msvc@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.9.1"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-win32-ia32-msvc@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.9.1"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@unrs/resolver-binding-win32-x64-msvc@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.9.1"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -8649,7 +8189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.3, anymatch@npm:^3.1.3, anymatch@npm:~3.1.2":
+"anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -8986,23 +8526,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:30.1.2":
-  version: 30.1.2
-  resolution: "babel-jest@npm:30.1.2"
-  dependencies:
-    "@jest/transform": "npm:30.1.2"
-    "@types/babel__core": "npm:^7.20.5"
-    babel-plugin-istanbul: "npm:^7.0.0"
-    babel-preset-jest: "npm:30.0.1"
-    chalk: "npm:^4.1.2"
-    graceful-fs: "npm:^4.2.11"
-    slash: "npm:^3.0.0"
-  peerDependencies:
-    "@babel/core": ^7.11.0
-  checksum: 10c0/c0f25d637708beeb210fc27b87a50bd4693de2e88b0ae89ea255fc1906dea362fde6ae81f602e3cd3c6b439eb7553bf0f3fca7b8f79681f6e2f1df8ec9576b00
-  languageName: node
-  linkType: hard
-
 "babel-jest@npm:^29.2.1, babel-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "babel-jest@npm:29.7.0"
@@ -9052,30 +8575,6 @@ __metadata:
     istanbul-lib-instrument: "npm:^5.0.4"
     test-exclude: "npm:^6.0.0"
   checksum: 10c0/1075657feb705e00fd9463b329921856d3775d9867c5054b449317d39153f8fbcebd3e02ebf00432824e647faff3683a9ca0a941325ef1afe9b3c4dd51b24beb
-  languageName: node
-  linkType: hard
-
-"babel-plugin-istanbul@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "babel-plugin-istanbul@npm:7.0.0"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.0.0"
-    "@istanbuljs/load-nyc-config": "npm:^1.0.0"
-    "@istanbuljs/schema": "npm:^0.1.3"
-    istanbul-lib-instrument: "npm:^6.0.2"
-    test-exclude: "npm:^6.0.0"
-  checksum: 10c0/79c37bd59ea9bcb16218e874993621e24048776fac7ee72eabe78f0909200851bdb93b32f6eba5b463206f15a1ee7ad40a725af8447952321ae1fdf14e740fe9
-  languageName: node
-  linkType: hard
-
-"babel-plugin-jest-hoist@npm:30.0.1":
-  version: 30.0.1
-  resolution: "babel-plugin-jest-hoist@npm:30.0.1"
-  dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.3"
-    "@types/babel__core": "npm:^7.20.5"
-  checksum: 10c0/49087f45c8ac359d68c622f4bd471300376b0ca2b6bd6ecaa1bd254ea87eda8fa3ce6144848e3bbabad337d276474a47e2ac3f6272f82e1f2337924ff49a02bd
   languageName: node
   linkType: hard
 
@@ -9179,7 +8678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-current-node-syntax@npm:^1.0.0, babel-preset-current-node-syntax@npm:^1.1.0":
+"babel-preset-current-node-syntax@npm:^1.0.0":
   version: 1.1.0
   resolution: "babel-preset-current-node-syntax@npm:1.1.0"
   dependencies:
@@ -9279,18 +8778,6 @@ __metadata:
     expo:
       optional: true
   checksum: 10c0/839bad8b415f79c3739eeebef99afdf506ba9dc16b1ac6fcdaa40216c534ce474621acc1775e546bedcd6049cbf5f1a5414dde68730445457bdb2d97fdd41a18
-  languageName: node
-  linkType: hard
-
-"babel-preset-jest@npm:30.0.1":
-  version: 30.0.1
-  resolution: "babel-preset-jest@npm:30.0.1"
-  dependencies:
-    babel-plugin-jest-hoist: "npm:30.0.1"
-    babel-preset-current-node-syntax: "npm:^1.1.0"
-  peerDependencies:
-    "@babel/core": ^7.11.0
-  checksum: 10c0/33da0094965929b1742b02e55272b544f189cd487d55bbba60e68d96d62d48f466264fe51f65950454829d4f2271541f2433e1c1c5e6a7ff5b9e91f1303471b7
   languageName: node
   linkType: hard
 
@@ -9759,7 +9246,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^3.0.0, callsites@npm:^3.1.0":
+"callsites@npm:^3.0.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
@@ -9783,7 +9270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.2.0, camelcase@npm:^6.3.0":
+"camelcase@npm:^6.2.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 10c0/0d701658219bd3116d12da3eab31acddb3f9440790c0792e0d398f0a520a6a4058018e546862b6fba89d7ae990efaeb97da71e1913e9ebf5a8b5621a3d55c710
@@ -10042,13 +9529,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "ci-info@npm:4.2.0"
-  checksum: 10c0/37a2f4b6a213a5cf835890eb0241f0d5b022f6cfefde58a69e9af8e3a0e71e06d6ad7754b0d4efb9cd2613e58a7a33996d71b56b0d04242722e86666f3f3d058
-  languageName: node
-  linkType: hard
-
 "ci-info@npm:^4.3.1":
   version: 4.3.1
   resolution: "ci-info@npm:4.3.1"
@@ -10065,10 +9545,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cjs-module-lexer@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "cjs-module-lexer@npm:2.1.0"
-  checksum: 10c0/91cf28686dc3948e4a06dfa03a2fccb14b7a97471ffe7ae0124f62060ddf2de28e8e997f60007babe6e122b1b06a47c01a1b72cc015f185824d9cac3ccfa5533
+"cjs-module-lexer@npm:^1.0.0":
+  version: 1.4.3
+  resolution: "cjs-module-lexer@npm:1.4.3"
+  checksum: 10c0/076b3af85adc4d65dbdab1b5b240fe5b45d44fcf0ef9d429044dd94d19be5589376805c44fb2d4b3e684e5fe6a9b7cf3e426476a6507c45283c5fc6ff95240be
   languageName: node
   linkType: hard
 
@@ -10258,7 +9738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"collect-v8-coverage@npm:^1.0.0, collect-v8-coverage@npm:^1.0.2":
+"collect-v8-coverage@npm:^1.0.0":
   version: 1.0.2
   resolution: "collect-v8-coverage@npm:1.0.2"
   checksum: 10c0/ed7008e2e8b6852c5483b444a3ae6e976e088d4335a85aa0a9db2861c5f1d31bd2d7ff97a60469b3388deeba661a619753afbe201279fb159b4b9548ab8269a1
@@ -10705,6 +10185,23 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
+  languageName: node
+  linkType: hard
+
+"create-jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "create-jest@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    chalk: "npm:^4.0.0"
+    exit: "npm:^0.1.2"
+    graceful-fs: "npm:^4.2.9"
+    jest-config: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    prompts: "npm:^2.0.1"
+  bin:
+    create-jest: bin/create-jest.js
+  checksum: 10c0/e7e54c280692470d3398f62a6238fd396327e01c6a0757002833f06d00afc62dd7bfe04ff2b9cd145264460e6b4d1eb8386f2925b7e567f97939843b7b0e812f
   languageName: node
   linkType: hard
 
@@ -11221,15 +10718,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dedent@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "dedent@npm:1.6.0"
+"dedent@npm:^1.0.0":
+  version: 1.7.0
+  resolution: "dedent@npm:1.7.0"
   peerDependencies:
     babel-plugin-macros: ^3.1.0
   peerDependenciesMeta:
     babel-plugin-macros:
       optional: true
-  checksum: 10c0/671b8f5e390dd2a560862c4511dd6d2638e71911486f78cb32116551f8f2aa6fcaf50579ffffb2f866d46b5b80fd72470659ca5760ede8f967619ef7df79e8a5
+  checksum: 10c0/c5e8a8beb5072bd5e520cb64b27a82d7ec3c2a63ee5ce47dbc2a05d5b7700cefd77a992a752cd0a8b1d979c1db06b14fb9486e805f3ad6088eda6e07cd9bf2d5
   languageName: node
   linkType: hard
 
@@ -11247,7 +10744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^4.3.0, deepmerge@npm:^4.3.1":
+"deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.0, deepmerge@npm:^4.3.1":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
@@ -11381,7 +10878,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-newline@npm:^3.1.0":
+"detect-newline@npm:^3.0.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: 10c0/c38cfc8eeb9fda09febb44bcd85e467c970d4e3bf526095394e5a4f18bc26dd0cf6b22c69c1fa9969261521c593836db335c2795218f6d781a512aea2fb8209d
@@ -12884,7 +12381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:5.1.1, execa@npm:^5.0.0, execa@npm:^5.1.1":
+"execa@npm:5.1.1, execa@npm:^5.0.0":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
   dependencies:
@@ -12955,24 +12452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exit-x@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "exit-x@npm:0.2.2"
-  checksum: 10c0/212a7a095ca5540e9581f1ef2d1d6a40df7a6027c8cc96e78ce1d16b86d1a88326d4a0eff8dff2b5ec1e68bb0c1edd5d0dfdde87df1869bf7514d4bc6a5cbd72
-  languageName: node
-  linkType: hard
-
-"expect@npm:30.1.2":
-  version: 30.1.2
-  resolution: "expect@npm:30.1.2"
-  dependencies:
-    "@jest/expect-utils": "npm:30.1.2"
-    "@jest/get-type": "npm:30.1.0"
-    jest-matcher-utils: "npm:30.1.2"
-    jest-message-util: "npm:30.1.0"
-    jest-mock: "npm:30.0.5"
-    jest-util: "npm:30.0.5"
-  checksum: 10c0/467c1b69549e75a1a09f3feec335e0dc968cd71370361b5d83248351cf77e705e8ddf38a4885e32a50237502ced7fcc9106462f59f33c4796462e95938b8ca19
+"exit@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "exit@npm:0.1.2"
+  checksum: 10c0/71d2ad9b36bc25bb8b104b17e830b40a08989be7f7d100b13269aaae7c3784c3e6e1e88a797e9e87523993a25ba27c8958959a554535370672cfb4d824af8989
   languageName: node
   linkType: hard
 
@@ -13428,7 +12911,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fb-watchman@npm:^2.0.0, fb-watchman@npm:^2.0.2":
+"fb-watchman@npm:^2.0.0":
   version: 2.0.2
   resolution: "fb-watchman@npm:2.0.2"
   dependencies:
@@ -13844,7 +13327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:^2.3.3, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -13854,7 +13337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -15260,7 +14743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-local@npm:^3.2.0":
+"import-local@npm:^3.0.2":
   version: 3.2.0
   resolution: "import-local@npm:3.2.0"
   dependencies:
@@ -15612,7 +15095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.16.0":
+"is-core-module@npm:^2.16.0, is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -15722,7 +15205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-generator-fn@npm:^2.1.0":
+"is-generator-fn@npm:^2.0.0":
   version: 2.1.0
   resolution: "is-generator-fn@npm:2.1.0"
   checksum: 10c0/2957cab387997a466cd0bf5c1b6047bd21ecb32bdcfd8996b15747aa01002c1c88731802f1b3d34ac99f4f6874b626418bd118658cf39380fe5fff32a3af9c4d
@@ -16256,7 +15739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-instrument@npm:^6.0.0, istanbul-lib-instrument@npm:^6.0.2":
+"istanbul-lib-instrument@npm:^6.0.0":
   version: 6.0.3
   resolution: "istanbul-lib-instrument@npm:6.0.3"
   dependencies:
@@ -16280,14 +15763,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-source-maps@npm:^5.0.0":
-  version: 5.0.6
-  resolution: "istanbul-lib-source-maps@npm:5.0.6"
+"istanbul-lib-source-maps@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "istanbul-lib-source-maps@npm:4.0.1"
   dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.23"
     debug: "npm:^4.1.1"
     istanbul-lib-coverage: "npm:^3.0.0"
-  checksum: 10c0/ffe75d70b303a3621ee4671554f306e0831b16f39ab7f4ab52e54d356a5d33e534d97563e318f1333a6aae1d42f91ec49c76b6cd3f3fb378addcb5c81da0255f
+    source-map: "npm:^0.6.1"
+  checksum: 10c0/19e4cc405016f2c906dff271a76715b3e881fa9faeb3f09a86cb99b8512b3a5ed19cadfe0b54c17ca0e54c1142c9c6de9330d65506e35873994e06634eebeb66
   languageName: node
   linkType: hard
 
@@ -16358,110 +15841,118 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-changed-files@npm:30.0.5":
-  version: 30.0.5
-  resolution: "jest-changed-files@npm:30.0.5"
+"jest-changed-files@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-changed-files@npm:29.7.0"
   dependencies:
-    execa: "npm:^5.1.1"
-    jest-util: "npm:30.0.5"
+    execa: "npm:^5.0.0"
+    jest-util: "npm:^29.7.0"
     p-limit: "npm:^3.1.0"
-  checksum: 10c0/41ce090f324e8450443327f19f772a9c3f225b4b1374ba9704358f0c8b8cd91fd134fa41df7db4d278428ab974c432abc3eca9484e67c8f18528974378fddef6
+  checksum: 10c0/e071384d9e2f6bb462231ac53f29bff86f0e12394c1b49ccafbad225ce2ab7da226279a8a94f421949920bef9be7ef574fd86aee22e8adfa149be73554ab828b
   languageName: node
   linkType: hard
 
-"jest-circus@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-circus@npm:30.1.3"
+"jest-circus@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-circus@npm:29.7.0"
   dependencies:
-    "@jest/environment": "npm:30.1.2"
-    "@jest/expect": "npm:30.1.2"
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/types": "npm:30.0.5"
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/expect": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
     "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
+    chalk: "npm:^4.0.0"
     co: "npm:^4.6.0"
-    dedent: "npm:^1.6.0"
-    is-generator-fn: "npm:^2.1.0"
-    jest-each: "npm:30.1.0"
-    jest-matcher-utils: "npm:30.1.2"
-    jest-message-util: "npm:30.1.0"
-    jest-runtime: "npm:30.1.3"
-    jest-snapshot: "npm:30.1.2"
-    jest-util: "npm:30.0.5"
+    dedent: "npm:^1.0.0"
+    is-generator-fn: "npm:^2.0.0"
+    jest-each: "npm:^29.7.0"
+    jest-matcher-utils: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
     p-limit: "npm:^3.1.0"
-    pretty-format: "npm:30.0.5"
-    pure-rand: "npm:^7.0.0"
+    pretty-format: "npm:^29.7.0"
+    pure-rand: "npm:^6.0.0"
     slash: "npm:^3.0.0"
-    stack-utils: "npm:^2.0.6"
-  checksum: 10c0/9bea7baf7daf814f3b494363e4ce321d98a2229078b6aff07f3a5623d93c99be11c9d07c0cbb75dcc9b4293dc13535c4c400500e69f08e869ed964b098fab3c8
+    stack-utils: "npm:^2.0.3"
+  checksum: 10c0/8d15344cf7a9f14e926f0deed64ed190c7a4fa1ed1acfcd81e4cc094d3cc5bf7902ebb7b874edc98ada4185688f90c91e1747e0dfd7ac12463b097968ae74b5e
   languageName: node
   linkType: hard
 
-"jest-cli@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-cli@npm:30.1.3"
+"jest-cli@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-cli@npm:29.7.0"
   dependencies:
-    "@jest/core": "npm:30.1.3"
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/types": "npm:30.0.5"
-    chalk: "npm:^4.1.2"
-    exit-x: "npm:^0.2.2"
-    import-local: "npm:^3.2.0"
-    jest-config: "npm:30.1.3"
-    jest-util: "npm:30.0.5"
-    jest-validate: "npm:30.1.0"
-    yargs: "npm:^17.7.2"
+    "@jest/core": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    chalk: "npm:^4.0.0"
+    create-jest: "npm:^29.7.0"
+    exit: "npm:^0.1.2"
+    import-local: "npm:^3.0.2"
+    jest-config: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    yargs: "npm:^17.3.1"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
     node-notifier:
       optional: true
   bin:
-    jest: ./bin/jest.js
-  checksum: 10c0/e15e811b0a14625ce70b1b3948955e9a9c7a523b2c7970effa8f924006dc4d1839b5636fa5c7c5c772d7959ed331a45b0e9d85d3b71f9a065aa6440ae3c1aa64
+    jest: bin/jest.js
+  checksum: 10c0/a658fd55050d4075d65c1066364595962ead7661711495cfa1dfeecf3d6d0a8ffec532f3dbd8afbb3e172dd5fd2fb2e813c5e10256e7cf2fea766314942fb43a
   languageName: node
   linkType: hard
 
-"jest-config@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-config@npm:30.1.3"
+"jest-config@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-config@npm:29.7.0"
   dependencies:
-    "@babel/core": "npm:^7.27.4"
-    "@jest/get-type": "npm:30.1.0"
-    "@jest/pattern": "npm:30.0.1"
-    "@jest/test-sequencer": "npm:30.1.3"
-    "@jest/types": "npm:30.0.5"
-    babel-jest: "npm:30.1.2"
-    chalk: "npm:^4.1.2"
-    ci-info: "npm:^4.2.0"
-    deepmerge: "npm:^4.3.1"
-    glob: "npm:^10.3.10"
-    graceful-fs: "npm:^4.2.11"
-    jest-circus: "npm:30.1.3"
-    jest-docblock: "npm:30.0.1"
-    jest-environment-node: "npm:30.1.2"
-    jest-regex-util: "npm:30.0.1"
-    jest-resolve: "npm:30.1.3"
-    jest-runner: "npm:30.1.3"
-    jest-util: "npm:30.0.5"
-    jest-validate: "npm:30.1.0"
-    micromatch: "npm:^4.0.8"
+    "@babel/core": "npm:^7.11.6"
+    "@jest/test-sequencer": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    babel-jest: "npm:^29.7.0"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    deepmerge: "npm:^4.2.2"
+    glob: "npm:^7.1.3"
+    graceful-fs: "npm:^4.2.9"
+    jest-circus: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    jest-regex-util: "npm:^29.6.3"
+    jest-resolve: "npm:^29.7.0"
+    jest-runner: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
     parse-json: "npm:^5.2.0"
-    pretty-format: "npm:30.0.5"
+    pretty-format: "npm:^29.7.0"
     slash: "npm:^3.0.0"
     strip-json-comments: "npm:^3.1.1"
   peerDependencies:
     "@types/node": "*"
-    esbuild-register: ">=3.4.0"
     ts-node: ">=9.0.0"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-    esbuild-register:
-      optional: true
     ts-node:
       optional: true
-  checksum: 10c0/9e347a22232d0368acad44719b1f6f3d5a7a39fd26156387c898904a3477e52267a5078624e7a3d231f05005679e21daaf080dec936ad44ac1f242500cd8d2bc
+  checksum: 10c0/bab23c2eda1fff06e0d104b00d6adfb1d1aabb7128441899c9bff2247bd26710b050a5364281ce8d52b46b499153bf7e3ee88b19831a8f3451f1477a0246a0f1
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:29.7.0, jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:^29.6.3"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
   languageName: node
   linkType: hard
 
@@ -16477,49 +15968,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:30.1.2":
-  version: 30.1.2
-  resolution: "jest-diff@npm:30.1.2"
-  dependencies:
-    "@jest/diff-sequences": "npm:30.0.1"
-    "@jest/get-type": "npm:30.1.0"
-    chalk: "npm:^4.1.2"
-    pretty-format: "npm:30.0.5"
-  checksum: 10c0/5baba5c54d044faf77540d2b97f947ce2a735c529bdca23ccd25669085ba3912eef2a8f66f4d765e8e416b1e10b95cb1dded0ebc1633efdbef37706b4e767ecb
-  languageName: node
-  linkType: hard
-
-"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
+"jest-docblock@npm:^29.7.0":
   version: 29.7.0
-  resolution: "jest-diff@npm:29.7.0"
+  resolution: "jest-docblock@npm:29.7.0"
   dependencies:
+    detect-newline: "npm:^3.0.0"
+  checksum: 10c0/d932a8272345cf6b6142bb70a2bb63e0856cc0093f082821577ea5bdf4643916a98744dfc992189d2b1417c38a11fa42466f6111526bc1fb81366f56410f3be9
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-each@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
     chalk: "npm:^4.0.0"
-    diff-sequences: "npm:^29.6.3"
     jest-get-type: "npm:^29.6.3"
+    jest-util: "npm:^29.7.0"
     pretty-format: "npm:^29.7.0"
-  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
-  languageName: node
-  linkType: hard
-
-"jest-docblock@npm:30.0.1":
-  version: 30.0.1
-  resolution: "jest-docblock@npm:30.0.1"
-  dependencies:
-    detect-newline: "npm:^3.1.0"
-  checksum: 10c0/f9bad2651db8afa029867ea7a40f422c9d73c67657360297371846a314a40c8786424be00483261df9137499f52c2af28cd458fbd15a7bf7fac8775b4bcd6ee1
-  languageName: node
-  linkType: hard
-
-"jest-each@npm:30.1.0":
-  version: 30.1.0
-  resolution: "jest-each@npm:30.1.0"
-  dependencies:
-    "@jest/get-type": "npm:30.1.0"
-    "@jest/types": "npm:30.0.5"
-    chalk: "npm:^4.1.2"
-    jest-util: "npm:30.0.5"
-    pretty-format: "npm:30.0.5"
-  checksum: 10c0/2db0fe6df0084b6e9e1eda8f024990c66ade49845f4259f2fd0bc64f31c709a49d66b8f3d7b4b09064bbd9c2acf8fdd320b9b29801050875d422b3f1004b6f7b
+  checksum: 10c0/f7f9a90ebee80cc688e825feceb2613627826ac41ea76a366fa58e669c3b2403d364c7c0a74d862d469b103c843154f8456d3b1c02b487509a12afa8b59edbb4
   languageName: node
   linkType: hard
 
@@ -16541,21 +16008,6 @@ __metadata:
     canvas:
       optional: true
   checksum: 10c0/139b94e2c8ec1bb5a46ce17df5211da65ce867354b3fd4e00fa6a0d1da95902df4cf7881273fc6ea937e5c325d39d6773f0d41b6c469363334de9d489d2c321f
-  languageName: node
-  linkType: hard
-
-"jest-environment-node@npm:30.1.2":
-  version: 30.1.2
-  resolution: "jest-environment-node@npm:30.1.2"
-  dependencies:
-    "@jest/environment": "npm:30.1.2"
-    "@jest/fake-timers": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    jest-mock: "npm:30.0.5"
-    jest-util: "npm:30.0.5"
-    jest-validate: "npm:30.1.0"
-  checksum: 10c0/6298269ba9e132634cc1548391a744387e8035f9b107cdd5250e6a813080c4099386ce55de8bdc68a12232f08d185d459b9517c50154107c8e070d49fcd8e879
   languageName: node
   linkType: hard
 
@@ -16608,28 +16060,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:30.1.0":
-  version: 30.1.0
-  resolution: "jest-haste-map@npm:30.1.0"
-  dependencies:
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    anymatch: "npm:^3.1.3"
-    fb-watchman: "npm:^2.0.2"
-    fsevents: "npm:^2.3.3"
-    graceful-fs: "npm:^4.2.11"
-    jest-regex-util: "npm:30.0.1"
-    jest-util: "npm:30.0.5"
-    jest-worker: "npm:30.1.0"
-    micromatch: "npm:^4.0.8"
-    walker: "npm:^1.0.8"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 10c0/a6001e350b0f1b4de6e4855130c516e3848c49fe90c50562f0eca525b80494f0d8ac1cc4d99013bdda9d2a5bd015e70abbcf3dbbf43b711fd39eaf7d47370220
-  languageName: node
-  linkType: hard
-
 "jest-haste-map@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-haste-map@npm:29.7.0"
@@ -16653,25 +16083,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-leak-detector@npm:30.1.0":
-  version: 30.1.0
-  resolution: "jest-leak-detector@npm:30.1.0"
+"jest-leak-detector@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-leak-detector@npm:29.7.0"
   dependencies:
-    "@jest/get-type": "npm:30.1.0"
-    pretty-format: "npm:30.0.5"
-  checksum: 10c0/a0b0c30988abab2efdf99fe8e00120c0b57406072efe2b1380270d0df4866812efe85903155682e2ec773164d8d0213e5ff59df1d8b343245dd4522d332c2853
-  languageName: node
-  linkType: hard
-
-"jest-matcher-utils@npm:30.1.2":
-  version: 30.1.2
-  resolution: "jest-matcher-utils@npm:30.1.2"
-  dependencies:
-    "@jest/get-type": "npm:30.1.0"
-    chalk: "npm:^4.1.2"
-    jest-diff: "npm:30.1.2"
-    pretty-format: "npm:30.0.5"
-  checksum: 10c0/c4f81fc7d72f94b18dff807adf787d6fd081c3e150148fbbcb1559c353b27890989bcf7e10b15d763625565175bf30019e93a014078ff291646a88a9acdfc9a4
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10c0/71bb9f77fc489acb842a5c7be030f2b9acb18574dc9fb98b3100fc57d422b1abc55f08040884bd6e6dbf455047a62f7eaff12aa4058f7cbdc11558718ca6a395
   languageName: node
   linkType: hard
 
@@ -16699,23 +16117,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:30.1.0":
-  version: 30.1.0
-  resolution: "jest-message-util@npm:30.1.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@jest/types": "npm:30.0.5"
-    "@types/stack-utils": "npm:^2.0.3"
-    chalk: "npm:^4.1.2"
-    graceful-fs: "npm:^4.2.11"
-    micromatch: "npm:^4.0.8"
-    pretty-format: "npm:30.0.5"
-    slash: "npm:^3.0.0"
-    stack-utils: "npm:^2.0.6"
-  checksum: 10c0/3884f7e772d64891eca63870f73b89af4e1dce715611c308e1115f7961ed378560bac66c5f9cbee025b06ca530dbd30685362cb8db7b5a48f5f53b75ba79023e
-  languageName: node
-  linkType: hard
-
 "jest-message-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-message-util@npm:29.7.0"
@@ -16733,17 +16134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:30.0.5":
-  version: 30.0.5
-  resolution: "jest-mock@npm:30.0.5"
-  dependencies:
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    jest-util: "npm:30.0.5"
-  checksum: 10c0/207fd79297f514a8e26ede9b4b5035e70212b8850a2f460b51d3cc58e8e7c9585bd2dbc5df2475a3321c4cd114b90e0b24190f00d6eeb88c8f088a8ed00416d5
-  languageName: node
-  linkType: hard
-
 "jest-mock@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-mock@npm:29.7.0"
@@ -16755,7 +16145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-pnp-resolver@npm:^1.2.3":
+"jest-pnp-resolver@npm:^1.2.2":
   version: 1.2.3
   resolution: "jest-pnp-resolver@npm:1.2.3"
   peerDependencies:
@@ -16767,13 +16157,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:30.0.1":
-  version: 30.0.1
-  resolution: "jest-regex-util@npm:30.0.1"
-  checksum: 10c0/f30c70524ebde2d1012afe5ffa5691d5d00f7d5ba9e43d588f6460ac6fe96f9e620f2f9b36a02d0d3e7e77bc8efb8b3450ae3b80ac53c8be5099e01bf54f6728
-  languageName: node
-  linkType: hard
-
 "jest-regex-util@npm:^29.0.0, jest-regex-util@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-regex-util@npm:29.6.3"
@@ -16781,89 +16164,89 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-resolve-dependencies@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-resolve-dependencies@npm:30.1.3"
+"jest-resolve-dependencies@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve-dependencies@npm:29.7.0"
   dependencies:
-    jest-regex-util: "npm:30.0.1"
-    jest-snapshot: "npm:30.1.2"
-  checksum: 10c0/1fc144c3107ad7faae455ac13b32de0cabb8e2718a55f431246a222da86c6da539f80230814b1cbcaf22c06df704c3c00ab761d065b9a9241659757e3fd28f66
+    jest-regex-util: "npm:^29.6.3"
+    jest-snapshot: "npm:^29.7.0"
+  checksum: 10c0/b6e9ad8ae5b6049474118ea6441dfddd385b6d1fc471db0136f7c8fbcfe97137a9665e4f837a9f49f15a29a1deb95a14439b7aec812f3f99d08f228464930f0d
   languageName: node
   linkType: hard
 
-"jest-resolve@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-resolve@npm:30.1.3"
+"jest-resolve@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve@npm:29.7.0"
   dependencies:
-    chalk: "npm:^4.1.2"
-    graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.1.0"
-    jest-pnp-resolver: "npm:^1.2.3"
-    jest-util: "npm:30.0.5"
-    jest-validate: "npm:30.1.0"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
+    jest-pnp-resolver: "npm:^1.2.2"
+    jest-util: "npm:^29.7.0"
+    jest-validate: "npm:^29.7.0"
+    resolve: "npm:^1.20.0"
+    resolve.exports: "npm:^2.0.0"
     slash: "npm:^3.0.0"
-    unrs-resolver: "npm:^1.7.11"
-  checksum: 10c0/ba84ac234ac2fd6ee4703aa2bb6471e5b4c17af7e36c1f75aae85a5d907694703b5501d5109d0fdc8875556a5a34dbf4fd7fe8732d4ee83cbbe1d88ef9c795b1
+  checksum: 10c0/59da5c9c5b50563e959a45e09e2eace783d7f9ac0b5dcc6375dea4c0db938d2ebda97124c8161310082760e8ebbeff9f6b177c15ca2f57fb424f637a5d2adb47
   languageName: node
   linkType: hard
 
-"jest-runner@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-runner@npm:30.1.3"
+"jest-runner@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runner@npm:29.7.0"
   dependencies:
-    "@jest/console": "npm:30.1.2"
-    "@jest/environment": "npm:30.1.2"
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/transform": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
+    "@jest/console": "npm:^29.7.0"
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
     "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
+    chalk: "npm:^4.0.0"
     emittery: "npm:^0.13.1"
-    exit-x: "npm:^0.2.2"
-    graceful-fs: "npm:^4.2.11"
-    jest-docblock: "npm:30.0.1"
-    jest-environment-node: "npm:30.1.2"
-    jest-haste-map: "npm:30.1.0"
-    jest-leak-detector: "npm:30.1.0"
-    jest-message-util: "npm:30.1.0"
-    jest-resolve: "npm:30.1.3"
-    jest-runtime: "npm:30.1.3"
-    jest-util: "npm:30.0.5"
-    jest-watcher: "npm:30.1.3"
-    jest-worker: "npm:30.1.0"
+    graceful-fs: "npm:^4.2.9"
+    jest-docblock: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    jest-haste-map: "npm:^29.7.0"
+    jest-leak-detector: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-resolve: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-watcher: "npm:^29.7.0"
+    jest-worker: "npm:^29.7.0"
     p-limit: "npm:^3.1.0"
     source-map-support: "npm:0.5.13"
-  checksum: 10c0/867f878892c88e8a050d2d687e44aedd661473c747c2a39e7b97297927b76c679710b229419ec3c237dfbbccf9061a3b953fa0d7ebfe4dd385c6048738658d33
+  checksum: 10c0/2194b4531068d939f14c8d3274fe5938b77fa73126aedf9c09ec9dec57d13f22c72a3b5af01ac04f5c1cf2e28d0ac0b4a54212a61b05f10b5d6b47f2a1097bb4
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-runtime@npm:30.1.3"
+"jest-runtime@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runtime@npm:29.7.0"
   dependencies:
-    "@jest/environment": "npm:30.1.2"
-    "@jest/fake-timers": "npm:30.1.2"
-    "@jest/globals": "npm:30.1.2"
-    "@jest/source-map": "npm:30.0.1"
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/transform": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/fake-timers": "npm:^29.7.0"
+    "@jest/globals": "npm:^29.7.0"
+    "@jest/source-map": "npm:^29.6.3"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
     "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
-    cjs-module-lexer: "npm:^2.1.0"
-    collect-v8-coverage: "npm:^1.0.2"
-    glob: "npm:^10.3.10"
-    graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.1.0"
-    jest-message-util: "npm:30.1.0"
-    jest-mock: "npm:30.0.5"
-    jest-regex-util: "npm:30.0.1"
-    jest-resolve: "npm:30.1.3"
-    jest-snapshot: "npm:30.1.2"
-    jest-util: "npm:30.0.5"
+    chalk: "npm:^4.0.0"
+    cjs-module-lexer: "npm:^1.0.0"
+    collect-v8-coverage: "npm:^1.0.0"
+    glob: "npm:^7.1.3"
+    graceful-fs: "npm:^4.2.9"
+    jest-haste-map: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    jest-regex-util: "npm:^29.6.3"
+    jest-resolve: "npm:^29.7.0"
+    jest-snapshot: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
     slash: "npm:^3.0.0"
     strip-bom: "npm:^4.0.0"
-  checksum: 10c0/2b5fe84685fddaca4e25cf4d578ab2bfdef2912e970be51a083ef0a7b6a8ff66f876aa72fb709674447fa57925551e2985af52d02a8c5d73d47a57b2057b5f95
+  checksum: 10c0/7cd89a1deda0bda7d0941835434e44f9d6b7bd50b5c5d9b0fc9a6c990b2d4d2cab59685ab3cb2850ed4cc37059f6de903af5a50565d7f7f1192a77d3fd6dd2a6
   languageName: node
   linkType: hard
 
@@ -16873,35 +16256,6 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
-  languageName: node
-  linkType: hard
-
-"jest-snapshot@npm:30.1.2":
-  version: 30.1.2
-  resolution: "jest-snapshot@npm:30.1.2"
-  dependencies:
-    "@babel/core": "npm:^7.27.4"
-    "@babel/generator": "npm:^7.27.5"
-    "@babel/plugin-syntax-jsx": "npm:^7.27.1"
-    "@babel/plugin-syntax-typescript": "npm:^7.27.1"
-    "@babel/types": "npm:^7.27.3"
-    "@jest/expect-utils": "npm:30.1.2"
-    "@jest/get-type": "npm:30.1.0"
-    "@jest/snapshot-utils": "npm:30.1.2"
-    "@jest/transform": "npm:30.1.2"
-    "@jest/types": "npm:30.0.5"
-    babel-preset-current-node-syntax: "npm:^1.1.0"
-    chalk: "npm:^4.1.2"
-    expect: "npm:30.1.2"
-    graceful-fs: "npm:^4.2.11"
-    jest-diff: "npm:30.1.2"
-    jest-matcher-utils: "npm:30.1.2"
-    jest-message-util: "npm:30.1.0"
-    jest-util: "npm:30.0.5"
-    pretty-format: "npm:30.0.5"
-    semver: "npm:^7.7.2"
-    synckit: "npm:^0.11.8"
-  checksum: 10c0/deca264b6564a5250f1f4153edefd8d626f880062e592656071507a71763b9ef9bcb88b5c011d7b18eb783d8be428ed35ab42f5f9227543dbf161cee586eeb4f
   languageName: node
   linkType: hard
 
@@ -16933,20 +16287,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:30.0.5":
-  version: 30.0.5
-  resolution: "jest-util@npm:30.0.5"
-  dependencies:
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    chalk: "npm:^4.1.2"
-    ci-info: "npm:^4.2.0"
-    graceful-fs: "npm:^4.2.11"
-    picomatch: "npm:^4.0.2"
-  checksum: 10c0/d3808b5f7720044d0464664c795e2b795ed82edf3b5871db74b8b603c3a0a38107668730348d26f92920ca3b8245a99cbbc2c93e77d0abb1f5e27524079a4ba8
-  languageName: node
-  linkType: hard
-
 "jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
@@ -16958,20 +16298,6 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     picomatch: "npm:^2.2.3"
   checksum: 10c0/bc55a8f49fdbb8f51baf31d2a4f312fb66c9db1483b82f602c9c990e659cdd7ec529c8e916d5a89452ecbcfae4949b21b40a7a59d4ffc0cd813a973ab08c8150
-  languageName: node
-  linkType: hard
-
-"jest-validate@npm:30.1.0":
-  version: 30.1.0
-  resolution: "jest-validate@npm:30.1.0"
-  dependencies:
-    "@jest/get-type": "npm:30.1.0"
-    "@jest/types": "npm:30.0.5"
-    camelcase: "npm:^6.3.0"
-    chalk: "npm:^4.1.2"
-    leven: "npm:^3.1.0"
-    pretty-format: "npm:30.0.5"
-  checksum: 10c0/6b8dd92e918496763827a9d440200657194b0158f70b42c9d4df373ff0504d063f342acdd12f692a8cb8610e7077c61289f934ae0c7878c9baff2d8be5efbc1f
   languageName: node
   linkType: hard
 
@@ -17017,23 +16343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-watcher@npm:30.1.3":
-  version: 30.1.3
-  resolution: "jest-watcher@npm:30.1.3"
-  dependencies:
-    "@jest/test-result": "npm:30.1.3"
-    "@jest/types": "npm:30.0.5"
-    "@types/node": "npm:*"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
-    emittery: "npm:^0.13.1"
-    jest-util: "npm:30.0.5"
-    string-length: "npm:^4.0.2"
-  checksum: 10c0/6783c17813afeddc333967f1dcc7ae8ac46269f6c45ff33b2d3665f5b697fb1ca70968903e6a4371e70cb7eab7a7e6cc2e446941c612e275e21f2dde7a666711
-  languageName: node
-  linkType: hard
-
-"jest-watcher@npm:^29.0.0":
+"jest-watcher@npm:^29.0.0, jest-watcher@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-watcher@npm:29.7.0"
   dependencies:
@@ -17046,19 +16356,6 @@ __metadata:
     jest-util: "npm:^29.7.0"
     string-length: "npm:^4.0.1"
   checksum: 10c0/ec6c75030562fc8f8c727cb8f3b94e75d831fc718785abfc196e1f2a2ebc9a2e38744a15147170039628a853d77a3b695561ce850375ede3a4ee6037a2574567
-  languageName: node
-  linkType: hard
-
-"jest-worker@npm:30.1.0":
-  version: 30.1.0
-  resolution: "jest-worker@npm:30.1.0"
-  dependencies:
-    "@types/node": "npm:*"
-    "@ungap/structured-clone": "npm:^1.3.0"
-    jest-util: "npm:30.0.5"
-    merge-stream: "npm:^2.0.0"
-    supports-color: "npm:^8.1.1"
-  checksum: 10c0/305a9c64d361e6be84e45d3b688da861569d43290a092ee05b8bc1e04fc5b3b8454423f14aa427902a5295487863fb857f7db79edbf2b9aca20874a94bc6f9a3
   languageName: node
   linkType: hard
 
@@ -17085,22 +16382,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^30.1.3":
-  version: 30.1.3
-  resolution: "jest@npm:30.1.3"
+"jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest@npm:29.7.0"
   dependencies:
-    "@jest/core": "npm:30.1.3"
-    "@jest/types": "npm:30.0.5"
-    import-local: "npm:^3.2.0"
-    jest-cli: "npm:30.1.3"
+    "@jest/core": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    import-local: "npm:^3.0.2"
+    jest-cli: "npm:^29.7.0"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
     node-notifier:
       optional: true
   bin:
-    jest: ./bin/jest.js
-  checksum: 10c0/6f0c18d8c94cfb3158cae90d048f38985b8aab9634f2fd8481f09ac0839697bf4a14fc3ed46d9d16e5bf653cad3af12547af62fbc46f64b3f06b32f8f8ee7d55
+    jest: bin/jest.js
+  checksum: 10c0/f40eb8171cf147c617cc6ada49d062fbb03b4da666cb8d39cdbfb739a7d75eea4c3ca150fb072d0d273dce0c753db4d0467d54906ad0293f59c54f9db4a09d8b
   languageName: node
   linkType: hard
 
@@ -20135,15 +19432,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"napi-postinstall@npm:^0.2.2":
-  version: 0.2.4
-  resolution: "napi-postinstall@npm:0.2.4"
-  bin:
-    napi-postinstall: lib/cli.js
-  checksum: 10c0/e8c357d7e27848c4af7becf2796afff245a2fc8ba176e1b133410bb1c9934a66d4bc542d0c9f04c73b0ba34ee0486b30b6cd1c62ed3aa36797d394200c9a2a8b
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -21550,13 +20838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "picomatch@npm:4.0.2"
-  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
-  languageName: node
-  linkType: hard
-
 "picomatch@npm:^4.0.3":
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
@@ -21589,13 +20870,6 @@ __metadata:
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 10c0/00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
-  languageName: node
-  linkType: hard
-
-"pirates@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "pirates@npm:4.0.7"
-  checksum: 10c0/a51f108dd811beb779d58a76864bbd49e239fa40c7984cd11596c75a121a8cc789f1c8971d8bb15f0dbf9d48b76c05bb62fcbce840f89b688c0fa64b37e8478a
   languageName: node
   linkType: hard
 
@@ -22655,7 +21929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.2.1, prompts@npm:^2.3.2, prompts@npm:^2.4.2":
+"prompts@npm:^2.0.1, prompts@npm:^2.2.1, prompts@npm:^2.3.2, prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:
@@ -22751,10 +22025,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "pure-rand@npm:7.0.1"
-  checksum: 10c0/9cade41030f5ec95f5d55a11a71404cd6f46b69becaad892097cd7f58e2c6248cd0a933349ca7d21336ab629f1da42ffe899699b671bc4651600eaf6e57f837e
+"pure-rand@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
   languageName: node
   linkType: hard
 
@@ -23938,7 +23212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve.exports@npm:^2.0.3":
+"resolve.exports@npm:^2.0.0, resolve.exports@npm:^2.0.3":
   version: 2.0.3
   resolution: "resolve.exports@npm:2.0.3"
   checksum: 10c0/1ade1493f4642a6267d0a5e68faeac20b3d220f18c28b140343feb83694d8fed7a286852aef43689d16042c61e2ddb270be6578ad4a13990769e12065191200d
@@ -23955,6 +23229,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/07e179f4375e1fd072cfb72ad66d78547f86e6196c4014b31cb0b8bb1db5f7ca871f922d08da0fbc05b94e9fd42206f819648fa3b5b873ebbc8e1dc68fec433a
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.20.0":
+  version: 1.22.11
+  resolution: "resolve@npm:1.22.11"
+  dependencies:
+    is-core-module: "npm:^2.16.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/f657191507530f2cbecb5815b1ee99b20741ea6ee02a59c57028e9ec4c2c8d7681afcc35febbd554ac0ded459db6f2d8153382c53a2f266cee2575e512674409
   languageName: node
   linkType: hard
 
@@ -24003,6 +23290,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
+  version: 1.22.11
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.16.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
   languageName: node
   linkType: hard
 
@@ -25128,7 +24428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.3, stack-utils@npm:^2.0.6":
+"stack-utils@npm:^2.0.3":
   version: 2.0.6
   resolution: "stack-utils@npm:2.0.6"
   dependencies:
@@ -25219,7 +24519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-length@npm:^4.0.1, string-length@npm:^4.0.2":
+"string-length@npm:^4.0.1":
   version: 4.0.2
   resolution: "string-length@npm:4.0.2"
   dependencies:
@@ -25615,7 +24915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
+"supports-color@npm:^8.0.0":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -25708,15 +25008,6 @@ __metadata:
     "@pkgr/core": "npm:^0.2.3"
     tslib: "npm:^2.8.1"
   checksum: 10c0/dd2965a37c93c0b652bf07b1fd8d1639a803b65cf34c0cb1b827b8403044fc3b09ec87f681d922a324825127ee95b2e0394e7caccb502f407892d63e903c5276
-  languageName: node
-  linkType: hard
-
-"synckit@npm:^0.11.8":
-  version: 0.11.8
-  resolution: "synckit@npm:0.11.8"
-  dependencies:
-    "@pkgr/core": "npm:^0.2.4"
-  checksum: 10c0/a1de5131ee527512afcaafceb2399b2f3e63678e56b831e1cb2dc7019c972a8b654703a3b94ef4166868f87eb984ea252b467c9d9e486b018ec2e6a55c24dfd8
   languageName: node
   linkType: hard
 
@@ -26765,73 +26056,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unrs-resolver@npm:^1.7.11":
-  version: 1.9.1
-  resolution: "unrs-resolver@npm:1.9.1"
-  dependencies:
-    "@unrs/resolver-binding-android-arm-eabi": "npm:1.9.1"
-    "@unrs/resolver-binding-android-arm64": "npm:1.9.1"
-    "@unrs/resolver-binding-darwin-arm64": "npm:1.9.1"
-    "@unrs/resolver-binding-darwin-x64": "npm:1.9.1"
-    "@unrs/resolver-binding-freebsd-x64": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-riscv64-gnu": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-riscv64-musl": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.9.1"
-    "@unrs/resolver-binding-linux-x64-musl": "npm:1.9.1"
-    "@unrs/resolver-binding-wasm32-wasi": "npm:1.9.1"
-    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.9.1"
-    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.9.1"
-    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.9.1"
-    napi-postinstall: "npm:^0.2.2"
-  dependenciesMeta:
-    "@unrs/resolver-binding-android-arm-eabi":
-      optional: true
-    "@unrs/resolver-binding-android-arm64":
-      optional: true
-    "@unrs/resolver-binding-darwin-arm64":
-      optional: true
-    "@unrs/resolver-binding-darwin-x64":
-      optional: true
-    "@unrs/resolver-binding-freebsd-x64":
-      optional: true
-    "@unrs/resolver-binding-linux-arm-gnueabihf":
-      optional: true
-    "@unrs/resolver-binding-linux-arm-musleabihf":
-      optional: true
-    "@unrs/resolver-binding-linux-arm64-gnu":
-      optional: true
-    "@unrs/resolver-binding-linux-arm64-musl":
-      optional: true
-    "@unrs/resolver-binding-linux-ppc64-gnu":
-      optional: true
-    "@unrs/resolver-binding-linux-riscv64-gnu":
-      optional: true
-    "@unrs/resolver-binding-linux-riscv64-musl":
-      optional: true
-    "@unrs/resolver-binding-linux-s390x-gnu":
-      optional: true
-    "@unrs/resolver-binding-linux-x64-gnu":
-      optional: true
-    "@unrs/resolver-binding-linux-x64-musl":
-      optional: true
-    "@unrs/resolver-binding-wasm32-wasi":
-      optional: true
-    "@unrs/resolver-binding-win32-arm64-msvc":
-      optional: true
-    "@unrs/resolver-binding-win32-ia32-msvc":
-      optional: true
-    "@unrs/resolver-binding-win32-x64-msvc":
-      optional: true
-  checksum: 10c0/fded9251b6c180c92c0510abe63e4fa9a5a4adcdcf3c9f7920507dc9f1ec756de5e71d1258f12bf4a32f7042e1fe142b6dc1003d8a6fb4d0bf1234226c879b01
-  languageName: node
-  linkType: hard
-
 "update-browserslist-db@npm:^1.1.1":
   version: 1.1.1
   resolution: "update-browserslist-db@npm:1.1.1"
@@ -27760,16 +26984,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "write-file-atomic@npm:5.0.1"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10c0/e8c850a8e3e74eeadadb8ad23c9d9d63e4e792bd10f4836ed74189ef6e996763959f1249c5650e232f3c77c11169d239cbfc8342fc70f3fe401407d23810505d
-  languageName: node
-  linkType: hard
-
 "write-file-atomic@npm:^6.0.0":
   version: 6.0.0
   resolution: "write-file-atomic@npm:6.0.0"
@@ -28034,7 +27248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.5.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+"yargs@npm:^17.3.1, yargs@npm:^17.5.1, yargs@npm:^17.6.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -28097,6 +27311,13 @@ __metadata:
   peerDependencies:
     zod: ^3.24.1
   checksum: 10c0/b907ab6d057100bd25a37e5545bf5f0efa5902cd84d3c3ec05c2e51541431a47bd9bf1e5e151a244273409b45f5986d55b26e5d207f98abc5200702f733eb368
+  languageName: node
+  linkType: hard
+
+"zod@npm:4.1.13":
+  version: 4.1.13
+  resolution: "zod@npm:4.1.13"
+  checksum: 10c0/d7e74e82dba81a91ffc3239cd85bc034abe193a28f7087a94ab258a3e48e9a7ca4141920cac979a0d781495b48fc547777394149f26be04c3dc642f58bbc3941
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Reasoning
This PR aligns the `MapView` more closely to GL JS. In my initial migration I switched to `{ longitude: number, latitude: number }` which seemed more aligned with React Native in general (like `locationX` and `locationY` in press events) and `react-map-gl` which use this in their [`ViewState`](https://visgl.github.io/react-map-gl/docs/api-reference/maplibre/map#initialviewstate).

Afterall I figured this is not the right approach, as it's not compatible with [`LngLatLike`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/LngLatLike/) of MapLibre GL JS. After discussions with @tyrauber we've settled for `[ longitude: number, latitude: number ]`, which is one of `LngLatLike` possibilities. It's also more close to `GeoJSON.Position`. It should be much superior not to invent another new format, but using one of the supported ones of MapLibre GL JS.

Also the `queryRenderedFeatures` method now aligns again with GL JS, sorry I got [confused by their docs](https://github.com/maplibre/maplibre-gl-js/pull/6821) about the right implementation.

I only kept the separate `longitude`/`latitude` props on the `GeolocationCoordinates` as this aligns with overall [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationCoordinates).

This PR also brings tests in JS and a few E2E tests especially to the imperative methods of MapView. Maestro seems rather limited for testing a library. Therefore I created two components, which can test for equality through jest equals or zod for more loose types.

# Migration
If you are using an v11 alpha this will be another round of breaking changes from previous breaking changes. Sorry for that!

If you are using TypeScript the migration should be straightforward and all found by linting, this parts are affected:

- `MapView`
  - Imperative methods involving geographical coordinates now uniformly use `[longitude: number, latitude: number]`
  - `queryRenderedFeatures` now correctly require pixel points instead of geographic coordinates
- `Camera`
  - `longitude`/`latitude` props have been replaced by `center` with `[longitude: number, latitude: number]`
  - Imperative methods involving geographical coordinates now uniformly use `[longitude: number, latitude: number]`