### PR TITLE
fix(OfflineManager): remove payload wrapper from events

### DIFF
--- a/src/__tests__/modules/offline/OfflineManager.test.js
+++ b/src/__tests__/modules/offline/OfflineManager.test.js
@@ -16,29 +16,20 @@ describe("OfflineManager", () => {
   };
 
   const mockOnProgressEvent = {
-    type: "offlinestatus",
-    payload: {
-      name: packOptions.name,
-      state: OfflinePackDownloadState.Active,
-      progress: 50.0,
-    },
+    name: packOptions.name,
+    state: OfflinePackDownloadState.Active,
+    progress: 50.0,
   };
 
   const mockOnProgressCompleteEvent = {
-    type: "offlinestatus",
-    payload: {
-      name: packOptions.name,
-      state: OfflinePackDownloadState.Complete,
-      progress: 100.0,
-    },
+    name: packOptions.name,
+    state: OfflinePackDownloadState.Complete,
+    progress: 100.0,
   };
 
   const mockErrorEvent = {
-    type: "offlineerror",
-    payload: {
-      name: packOptions.name,
-      message: "unit test error",
-    },
+    name: packOptions.name,
+    message: "unit test error",
   };
 
   afterEach(async () => {
@@ -109,7 +100,7 @@ describe("OfflineManager", () => {
       OfflineManager._onProgress(mockOnProgressEvent);
       expect(listener).toHaveBeenCalledWith(
         expectedOfflinePack,
-        mockOnProgressEvent.payload,
+        mockOnProgressEvent,
       );
     });
 
@@ -122,7 +113,7 @@ describe("OfflineManager", () => {
       OfflineManager._onError(mockErrorEvent);
       expect(listener).toHaveBeenCalledWith(
         expectedOfflinePack,
-        mockErrorEvent.payload,
+        mockErrorEvent,
       );
     });
 

--- a/src/modules/offline/OfflineManager.ts
+++ b/src/modules/offline/OfflineManager.ts
@@ -22,14 +22,6 @@ export type OfflinePackError = {
   message: string;
 };
 
-type ErrorEvent = {
-  payload: OfflinePackError;
-};
-
-type ProgressEvent = {
-  payload: OfflinePackStatus;
-};
-
 type ProgressListener = (pack: OfflinePack, status: OfflinePackStatus) => void;
 type ErrorListener = (pack: OfflinePack, err: OfflinePackError) => void;
 
@@ -378,8 +370,8 @@ class OfflineManager {
     return true;
   }
 
-  _onProgress(e: ProgressEvent): void {
-    const { name, state } = e.payload;
+  _onProgress(e: OfflinePackStatus): void {
+    const { name, state } = e;
 
     if (!this._hasListeners(name, this._progressListeners)) {
       return;
@@ -387,7 +379,7 @@ class OfflineManager {
 
     const pack = this._offlinePacks[name];
     if (pack) {
-      this._progressListeners[name]?.(pack, e.payload);
+      this._progressListeners[name]?.(pack, e);
     }
 
     // cleanup listeners now that they are no longer needed
@@ -396,8 +388,8 @@ class OfflineManager {
     }
   }
 
-  _onError(e: ErrorEvent): void {
-    const { name } = e.payload;
+  _onError(e: OfflinePackError): void {
+    const { name } = e;
 
     if (!this._hasListeners(name, this._errorListeners)) {
       return;
@@ -405,7 +397,7 @@ class OfflineManager {
 
     const pack = this._offlinePacks[name];
     if (pack) {
-      this._errorListeners[name]?.(pack, e.payload);
+      this._errorListeners[name]?.(pack, e);
     }
   }
 


### PR DESCRIPTION
on alpha version, I was receiving this error:

```js
 ERROR  [TypeError: Cannot read property 'name' of undefined]

Code: OfflineManager.js
  305 |   _onProgress(e) {
  306 |     const {
> 307 |       name,
      |           ^
  308 |       state
  309 |     } = e.payload;
  310 |     if (!this._hasListeners(name, this._progressListeners)) {
Call Stack
  _onProgress (node_modules/@maplibre/maplibre-react-native/lib/module/modules/offline/OfflineManager.js:307:11)
  apply (<native>)
  emit (node_modules/react-native/Libraries/vendor/emitter/EventEmitter.js:130:36)
  apply (<native>)
  <anonymous> (node_modules/@babel/runtime/helpers/superPropGet.js:6:19)
  RCTDeviceEventEmitterImpl#emit (node_modules/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.js:33:5)
```

Native events are sent directly without a `payload` wrapper, but `_onProgress` and `_onError` were trying to access `e.payload`.

This matches the pattern used in `LocationManager`

