### PR TITLE
fix(GeoJSONSource): clearing clusterProperties

### DIFF
--- a/ios/components/map-view/MLRNMapViewComponentView.mm
+++ b/ios/components/map-view/MLRNMapViewComponentView.mm
@@ -58,13 +58,6 @@ ViewState createViewState(NSDictionary *dict) {
   return result;
 }
 
-static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn) {
-  if (dyn.isNull() || !dyn.isObject()) {
-    return nil;
-  }
-  return (NSDictionary *)convertFollyDynamicToId(dyn);
-}
-
 // MARK: - MLRNMapViewComponentView
 
 @interface MLRNMapViewComponentView () <RCTMLRNMapViewViewProtocol>
@@ -302,7 +295,7 @@ static NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn
 
   if (oldViewProps.light != newViewProps.light) {
     NSDictionary *reactLight = (!newViewProps.light.isNull() && newViewProps.light.isObject())
-                                   ? convertFollyDynamicToNSDictionary(newViewProps.light)
+                                   ? convertFollyDynamicToId(newViewProps.light)
                                    : nil;
     [_view setReactLight:reactLight];
   }

--- a/ios/components/sources/geojson-source/MLRNGeoJSONSourceComponentView.mm
+++ b/ios/components/sources/geojson-source/MLRNGeoJSONSourceComponentView.mm
@@ -99,7 +99,10 @@ using namespace facebook::react;
   }
 
   if (oldViewProps.clusterProperties != newViewProps.clusterProperties) {
-    _view.clusterProperties = convertFollyDynamicToId(newViewProps.clusterProperties);
+    _view.clusterProperties =
+        (!newViewProps.clusterProperties.isNull() && newViewProps.clusterProperties.isObject())
+            ? convertFollyDynamicToId(newViewProps.clusterProperties)
+            : nil;
   }
 
   if (oldViewProps.maxzoom != newViewProps.maxzoom) {

--- a/ios/modules/network/MLRNNetworkHTTPHeaders.h
+++ b/ios/modules/network/MLRNNetworkHTTPHeaders.h
@@ -3,12 +3,12 @@
 
 @interface MLRNNetworkHTTPHeaders : NSObject <MLNNetworkConfigurationDelegate>
 
-+ (id)sharedInstance;
++ (id _Nonnull)sharedInstance;
 
-- (void)addRequestHeader:(NSString *)name
-                   value:(NSString *)value
+- (void)addRequestHeader:(nonnull NSString *)name
+                   value:(nonnull NSString *)value
                    match:(nullable NSString *)match;
 
-- (void)removeRequestHeader:(NSString *)header;
+- (void)removeRequestHeader:(nonnull NSString *)header;
 
 @end


### PR DESCRIPTION
When switching from Earthquakes example to another one using `GeoJSONSource` a crash occured due to setting `NSNull` instead of `nil` when the value cleared for `clusterProperties`. Fixed some warning and aligned the pattern for all folly converts.