### PR TITLE
fix(iOS): ImageSource load initial local url

### DIFF
--- a/ios/components/sources/image-source/MLRNImageSource.m
+++ b/ios/components/sources/image-source/MLRNImageSource.m
@@ -21,18 +21,9 @@
 }
 
 - (nullable MLNSource *)makeSource {
-  NSURL *myURL;
-
-  if ([[_url substringToIndex:4] isEqualToString:@"http"]) {
-    myURL = [NSURL URLWithString:_url];
-  } else {
-    // Default consider it file url path
-    myURL = [NSURL fileURLWithPath:_url];
-  }
-
   return [[MLNImageSource alloc] initWithIdentifier:self.id
                                      coordinateQuad:[self _makeCoordQuad]
-                                                URL:myURL];
+                                                URL:[NSURL URLWithString:_url]];
 }
 
 - (MLNCoordinateQuad)_makeCoordQuad {


### PR DESCRIPTION
Fixes #872

Reproduction, needs `expo-file-system` installed:
```tsx
import { ImageSource, Layer, MapView } from "@maplibre/maplibre-react-native";
import { File, Paths } from "expo-file-system";
import { useEffect, useState } from "react";

const imageURL =
  "https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Orange_tabby_cat_sitting_on_fallen_leaves-Hisashi-01A.jpg/1280px-Orange_tabby_cat_sitting_on_fallen_leaves-Hisashi-01A.jpg";

function sleep(ms: number) {
  return new Promise((resolve) => setTimeout(resolve, ms));
}

async function fetchImage() {
  const filepath = Paths.join(
    Paths.cache,
    `${(Math.random() * 10000000000).toFixed(0)}.jpg`,
  );
  console.log("Downloading image to", filepath);
  const res = await fetch(new Request(imageURL));
  const bytes = new Uint8Array(await res.arrayBuffer());
  const file = new File(filepath);
  file.create();

  const handle = file.open();
  try {
    handle.writeBytes(bytes);
  } finally {
    handle.close();
  }

  console.log("Done");
  await sleep(100);
  return filepath;
}

export function BugReport() {
  const [image, setImage] = useState<string | undefined>(undefined);

  useEffect(() => {
    (async () => {
      setImage(await fetchImage());
    })();
  }, []);

  return (
    <MapView mapStyle="https://demotiles.maplibre.org/style.json">
      {image && (
        <ImageSource
          url={image}
          coordinates={[
            [-18, 64],
            [8, 64],
            [8, 44],
            [-18, 44],
          ]}
        >
          <Layer type="raster" style={{ rasterOpacity: 0.7 }} />
        </ImageSource>
      )}
    </MapView>
  );
}
```