### PR TITLE
fix(iOS): reset Camera initialViewState for recycle

### DIFF
--- a/ios/components/camera/MLRNCameraComponentView.mm
+++ b/ios/components/camera/MLRNCameraComponentView.mm
@@ -32,6 +32,12 @@ using namespace facebook::react;
   return self;
 }
 
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  [_view setInitialViewState:nil];
+  [_view setStop:nil];
+}
+
 - (void)prepareView {
   _view = [[MLRNCamera alloc] init];
 


### PR DESCRIPTION
## Summary
- Adds `prepareForRecycle` to `MLRNCameraComponentView` to reset `initialViewState` and `stop` when Fabric recycles the native view
- Fixes issue where navigating from a controlled Camera example (e.g. GeoJSONSource FeatureCollection) to one using `initialViewState` (e.g. GradientLine) would not apply the new initial camera position

## Test plan
- [ ] Open "Fill/RasterLayer → GeoJSONSource FeatureCollection" example
- [ ] Navigate back, then open "LineLayer → GradientLine" example
- [ ] Verify the map centers on DC area at zoom 12 with the gradient line visible