### PR TITLE
Fix Marker and ViewAnnotation compatibility with Reanimated

### DIFF
--- a/src/components/annotations/marker/Marker.tsx
+++ b/src/components/annotations/marker/Marker.tsx
@@ -1,44 +1,12 @@
-import {
-  Component,
-  type ComponentProps,
-  type ReactElement,
-  type Ref,
-  useImperativeHandle,
-  useRef,
-} from "react";
-import {
-  Platform,
-  type ReactNativeElement,
-  View,
-  type ViewProps,
-} from "react-native";
+import type { ReactElement } from "react";
+import { Platform, View, type ViewProps } from "react-native";
 
 import MarkerViewNativeComponent from "./MarkerViewNativeComponent";
 import { useFrozenId } from "../../../hooks/useFrozenId";
 import { type Anchor, anchorToNative } from "../../../types/Anchor";
 import type { LngLat } from "../../../types/LngLat";
 import type { PixelPoint } from "../../../types/PixelPoint";
-import {
-  type NativeViewAnnotationRef,
-  ViewAnnotation,
-  type ViewAnnotationRef,
-} from "../view-annotation/ViewAnnotation";
-
-export type NativeMarkerRef = Component<
-  ComponentProps<typeof MarkerViewNativeComponent>
-> &
-  ReactNativeElement;
-
-export interface MarkerRef {
-  /**
-   * Returns a reference to the native component for Reanimated compatibility.
-   * This method is used by Reanimated's createAnimatedComponent to determine
-   * which component should receive animated props.
-   *
-   * @see https://docs.swmansion.com/react-native-reanimated/docs/core/createAnimatedComponent/#component
-   */
-  getAnimatableRef(): NativeMarkerRef | NativeViewAnnotationRef | null;
-}
+import { ViewAnnotation } from "../view-annotation/ViewAnnotation";
 
 export interface MarkerProps extends ViewProps {
   /**
@@ -83,11 +51,6 @@ export interface MarkerProps extends ViewProps {
    * Expects one child - can be a View with multiple elements.
    */
   children: ReactElement;
-
-  /**
-   * Ref to access Marker methods.
-   */
-  ref?: Ref<MarkerRef>;
 }
 
 /**
@@ -103,31 +66,16 @@ export const Marker = ({
   id,
   anchor = "center",
   offset,
-  ref,
   ...props
 }: MarkerProps) => {
-  const nativeRef = useRef<NativeMarkerRef>(null);
-  const viewAnnotationRef = useRef<ViewAnnotationRef>(null);
-
   const nativeAnchor = anchorToNative(anchor);
   const nativeOffset = offset ? { x: offset[0], y: offset[1] } : undefined;
 
   const frozenId = useFrozenId(id);
 
-  useImperativeHandle(
-    ref,
-    (): MarkerRef => ({
-      getAnimatableRef: () =>
-        Platform.OS === "ios"
-          ? (viewAnnotationRef.current?.getAnimatableRef() ?? null)
-          : nativeRef.current,
-    }),
-  );
-
   if (Platform.OS === "ios") {
     return (
       <ViewAnnotation
-        ref={viewAnnotationRef}
         id={frozenId}
         anchor={anchor}
         offset={offset}
@@ -138,7 +86,6 @@ export const Marker = ({
 
   return (
     <MarkerViewNativeComponent
-      ref={nativeRef}
       id={frozenId}
       anchor={nativeAnchor}
       offset={nativeOffset}

--- a/src/components/annotations/view-annotation/ViewAnnotation.tsx
+++ b/src/components/annotations/view-annotation/ViewAnnotation.tsx
@@ -133,7 +133,7 @@ export interface ViewAnnotationProps {
   /**
    * Ref to access ViewAnnotation methods.
    */
-  ref?: Ref<ViewAnnotationRef>;
+  refreshRef?: Ref<ViewAnnotationRef>;
 }
 
 export interface ViewAnnotationRef {
@@ -143,15 +143,6 @@ export interface ViewAnnotationRef {
    * Call this for example from Image#onLoad.
    */
   refresh(): void;
-
-  /**
-   * Returns a reference to the native component for Reanimated compatibility.
-   * This method is used by Reanimated's createAnimatedComponent to determine
-   * which component should receive animated props.
-   *
-   * @see https://docs.swmansion.com/react-native-reanimated/docs/core/createAnimatedComponent/#component
-   */
-  getAnimatableRef(): NativeViewAnnotationRef | null;
 }
 
 /**
@@ -168,7 +159,11 @@ export const ViewAnnotation = ({
   anchor = "center",
   draggable = false,
   offset,
+  //? @unendingblue: i think removing the explicit `ref` here breaks the
+  //? imperative handle when the component has been passed through `Animated.createAnimatedComponent`,
+  //? even though it's not used anywhere
   ref,
+  refreshRef,
   ...props
 }: ViewAnnotationProps) => {
   const frozenId = useFrozenId(id);
@@ -176,13 +171,7 @@ export const ViewAnnotation = ({
   const nativeOffset = offset ? { x: offset[0], y: offset[1] } : undefined;
   const nativeRef = useRef<NativeViewAnnotationRef>(null);
 
-  useImperativeHandle(
-    ref,
-    (): ViewAnnotationRef => ({
-      refresh,
-      getAnimatableRef: () => nativeRef.current,
-    }),
-  );
+  useImperativeHandle(refreshRef, (): ViewAnnotationRef => ({ refresh }));
 
   function refresh(): void {
     if (Platform.OS === "android" && nativeRef.current) {


### PR DESCRIPTION
This PR fixes compatibility with Reanimated for Marker and ViewAnnotation. More specifically:

**Marker**
- `useImperativeHandle` is removed since it's dead code. This is only useful for invoking `refresh` on Android `ViewAnnotation`s, but in this case `ViewAnnotation` is only used for iOS.
- Removed manual `ref` to allow React/Reanimated to naturally travel down the component

**ViewAnnotation**
- Instead of using `ref` to control `refresh`, the imperative handle is now attached to `refreshRef`. This prevents the imperative handle from messing with Reanimated.
- I left a note as a comment as well, but for some reason, if I remove the explicit `ref` from the component props, calling `refresh` does not work if the ViewAnnotation has been passed through `createAnimatedComponent`