### PR TITLE
fix(Android): revert location engine to default

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,6 +11,6 @@ org.maplibre.reactnative.pluginVersion=3.0.2
 org.maplibre.reactnative.turfVersion=6.0.1
 org.maplibre.reactnative.okhttpVersion=4.12.0
 # Available values: default, google
-org.maplibre.reactnative.locationEngine=google
+org.maplibre.reactnative.locationEngine=default
 # Only applied if locationEngine=google
 org.maplibre.reactnative.googlePlayServicesLocationVersion=21.3.0

--- a/examples/expo-app/app.config.ts
+++ b/examples/expo-app/app.config.ts
@@ -38,7 +38,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       "../../src/plugin/withMapLibre.ts",
       {
-        android: { locationEngine: "google" },
+        android: {
+          // Allow location simulation in emulator
+          locationEngine: "google",
+        },
         ios: {},
       } as MapLibrePluginProps,
     ],

--- a/examples/expo-app/app.config.ts
+++ b/examples/expo-app/app.config.ts
@@ -8,7 +8,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Expo App",
   slug: "maplibre-react-native-expo-example",
   version: "1.0.0",
-  newArchEnabled: true,
   orientation: "portrait",
   icon: "./assets/icon.png",
   splash: {
@@ -39,7 +38,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       "../../src/plugin/withMapLibre.ts",
       {
-        android: {},
+        android: { locationEngine: "google" },
         ios: {},
       } as MapLibrePluginProps,
     ],

--- a/examples/react-native-app/android/gradle.properties
+++ b/examples/react-native-app/android/gradle.properties
@@ -42,3 +42,6 @@ hermesEnabled=true
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
+
+# To allow debugging in emulator we must use google location engine
+org.maplibre.reactnative.locationEngine=google

--- a/examples/react-native-app/android/gradle.properties
+++ b/examples/react-native-app/android/gradle.properties
@@ -43,5 +43,5 @@ hermesEnabled=true
 # Note: Only works with ReactActivity and should not be used with custom Activity.
 edgeToEdgeEnabled=false
 
-# To allow debugging in emulator we must use google location engine
+# Allow location simulation in emulator
 org.maplibre.reactnative.locationEngine=google


### PR DESCRIPTION
I accidentally pushed `google` as the location engine, but it should stay `default`. To allow debugging I've set the example apps to use `google` location engine, because the `default` doesn't work in Android emulator.