### PR TITLE
docs: fix typo in iOS setup

### DIFF
--- a/docs/content/setup/react-native.md
+++ b/docs/content/setup/react-native.md
@@ -16,8 +16,7 @@ Android doesn't need any further specific setup. Simply rebuild your app.
 
 ## iOS
 
-On iOS it's necessary to add `$MLRN.post_install(installer)` to the `post_install` block in the `ios/Podfile` is
-necessary:
+On iOS it's necessary to add `$MLRN.post_install(installer)` to the `post_install` block in the `ios/Podfile`:
 
 ```diff
 post_install do |installer|


### PR DESCRIPTION
`is necessary` was duplicated