### PR TITLE
fix(Android): emit onRegionIsChanging from Map for double tap zoom

### DIFF
--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
@@ -417,6 +417,10 @@ open class MLRNMapView(
             handleMapChangedEvent("onRegionWillChange", true)
         }
 
+        mapLibreMap.addOnCameraMoveListener {
+            handleMapChangedEvent("onRegionIsChanging", true)
+        }
+
         mapLibreMap.addOnMoveListener(
             object : MapLibreMap.OnMoveListener {
                 override fun onMoveBegin(detector: MoveGestureDetector) {
@@ -425,8 +429,7 @@ open class MLRNMapView(
                 }
 
                 override fun onMove(detector: MoveGestureDetector) {
-                    cameraChangeTracker.setReason(CameraChangeTracker.USER_GESTURE)
-                    handleMapChangedEvent("onRegionIsChanging", true)
+                    // Handled by mapLibreMap.addOnCameraMoveListener
                 }
 
                 override fun onMoveEnd(detector: MoveGestureDetector) {
@@ -622,7 +625,7 @@ open class MLRNMapView(
     }
 
     override fun onCameraIsChanging() {
-        handleMapChangedEvent("onRegionIsChanging", true)
+        // Handled by mapLibreMap.addOnCameraMoveListener
     }
 
     override fun onWillStartLoadingMap() {

--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
@@ -91,7 +91,6 @@ open class MLRNMapView(
     OnMapReadyCallback,
     MapLibreMap.OnMapClickListener,
     MapLibreMap.OnMapLongClickListener,
-    MapView.OnCameraIsChangingListener,
     MapView.OnCameraDidChangeListener,
     MapView.OnWillStartLoadingMapListener,
     MapView.OnDidFailLoadingMapListener,
@@ -347,7 +346,6 @@ open class MLRNMapView(
 
         setLifecycleListeners()
 
-        addOnCameraIsChangingListener(this)
         addOnCameraDidChangeListener(this)
         addOnDidFailLoadingMapListener(this)
         addOnDidFinishLoadingMapListener(this)
@@ -622,10 +620,6 @@ open class MLRNMapView(
 
     override fun onCameraDidChange(animated: Boolean) {
         cameraChangeTracker.isAnimating = animated
-    }
-
-    override fun onCameraIsChanging() {
-        // Handled by mapLibreMap.addOnCameraMoveListener
     }
 
     override fun onWillStartLoadingMap() {


### PR DESCRIPTION
Fixes #644

Testing:

```tsx
import { Camera, Map } from "@maplibre/maplibre-react-native";
import { useState } from "react";
import { Button } from "react-native";

export function BugReport() {
  const [test, setTest] = useState(false);

  return (
    <>
      <Map
        mapStyle="https://demotiles.maplibre.org/style.json"
        onRegionIsChanging={(event) => {
          event.persist();
          console.log("onRegionIsChanging", event.nativeEvent.userInteraction);
        }}
        onRegionDidChange={(event) => {
          event.persist();
          console.log("onRegionDidChange", event.nativeEvent.userInteraction);
        }}
      >
        {test && <Camera center={[50, 10]} zoom={15} />}
      </Map>
      <Button
        title="test"
        onPress={() => {
          setTest((prev) => !prev);
        }}
      />
    </>
  );
}
```