### PR TITLE
fix: add getAnimatableRef for reanimated v4 compatibility

### DIFF
--- a/docs/content/components/general/marker.md
+++ b/docs/content/components/general/marker.md
@@ -19,3 +19,8 @@ Marker allows you to place an interactive React Native View on the map.<br/><br/
 | `selected` |   `boolean`    |   `none`   | `false`  | Manually selects/deselects the marker.<br/><br/>@platform iOS                                                                                                                                                                                                                            |
 | `onPress`  |     `func`     |   `none`   | `false`  | This callback is fired when the marker is pressed.<br/>_signature:_`(event:NativeSyntheticEvent) => void`                                                                                                                                                                                |
 | `children` | `ReactElement` |   `none`   |  `true`  | Expects one child - can be a View with multiple elements.                                                                                                                                                                                                                                |
+| `ref`      |     `Ref`      |   `none`   | `false`  | Ref to access Marker methods.                                                                                                                                                                                                                                                            |
+
+## Methods
+
+### `getAnimatableRef()`

--- a/docs/content/components/general/view-annotation.md
+++ b/docs/content/components/general/view-annotation.md
@@ -33,3 +33,5 @@ ViewAnnotation represents a one-dimensional shape located at a single geographic
 ## Methods
 
 ### `refresh()`
+
+### `getAnimatableRef()`

--- a/docs/content/docs.json
+++ b/docs/content/docs.json
@@ -940,7 +940,15 @@
   "Marker": {
     "description": "Marker allows you to place an interactive React Native View on the map.\n\nIf you have static view consider using ViewAnnotation or SymbolLayer for better performance.\n\nImplemented through:\n- Android: Native Views placed on the map projection\n- iOS: [MLNPointAnnotation](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre/mlnpointannotation/)",
     "displayName": "Marker",
-    "methods": [],
+    "methods": [
+      {
+        "name": "getAnimatableRef",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
+      }
+    ],
     "props": [
       {
         "name": "id",
@@ -993,6 +1001,13 @@
         "type": "ReactElement",
         "default": "none",
         "description": "Expects one child - can be a View with multiple elements."
+      },
+      {
+        "name": "ref",
+        "required": false,
+        "type": "Ref",
+        "default": "none",
+        "description": "Ref to access Marker methods."
       }
     ],
     "composes": ["ViewProps"],
@@ -1623,6 +1638,13 @@
     "methods": [
       {
         "name": "refresh",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
+      },
+      {
+        "name": "getAnimatableRef",
         "docblock": null,
         "modifiers": [],
         "params": [],

--- a/package/src/components/annotations/marker/Marker.tsx
+++ b/package/src/components/annotations/marker/Marker.tsx
@@ -121,10 +121,20 @@ export const Marker = ({
   const frozenId = useFrozenId(id);
 
   useImperativeHandle(ref, () => ({
-    getAnimatableRef: () =>
-      Platform.OS === "ios"
-        ? (viewAnnotationRef.current?.getAnimatableRef() as NativeMarkerRef | null)
-        : nativeRef.current,
+    // Reanimated v4 compatibility: createAnimatedComponent looks for _viewConfig but native has __viewConfig
+    getAnimatableRef: () => {
+      if (Platform.OS === "ios") {
+        return viewAnnotationRef.current?.getAnimatableRef() as NativeMarkerRef | null;
+      }
+      return nativeRef.current
+        ? new Proxy(nativeRef.current, {
+            get: (target, prop) =>
+              prop === "_viewConfig"
+                ? (target as unknown as { __viewConfig: unknown }).__viewConfig
+                : target[prop as keyof typeof target],
+          })
+        : null;
+    },
   }));
 
   if (Platform.OS === "ios") {

--- a/package/src/components/annotations/marker/Marker.tsx
+++ b/package/src/components/annotations/marker/Marker.tsx
@@ -1,4 +1,11 @@
-import { Component, type ComponentProps, type ReactElement } from "react";
+import {
+  Component,
+  type ComponentProps,
+  type ReactElement,
+  type Ref,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import {
   type NativeSyntheticEvent,
   Platform,
@@ -13,7 +20,10 @@ import { type Anchor, anchorToNative } from "../../../types/Anchor";
 import type { LngLat } from "../../../types/LngLat";
 import type { PixelPoint } from "../../../types/PixelPoint";
 import type { PressEvent } from "../../../types/PressEvent";
-import { ViewAnnotation } from "../view-annotation/ViewAnnotation";
+import {
+  ViewAnnotation,
+  type ViewAnnotationRef,
+} from "../view-annotation/ViewAnnotation";
 
 export type NativeMarkerRef = Component<
   ComponentProps<typeof MarkerViewNativeComponent>
@@ -23,6 +33,13 @@ export type NativeMarkerRef = Component<
 export type MarkerEvent = PressEvent & {
   id: string;
 };
+
+export interface MarkerRef {
+  /**
+   * Returns the native ref for Reanimated v4 compatibility.
+   */
+  getAnimatableRef(): NativeMarkerRef | null;
+}
 
 export interface MarkerProps extends ViewProps {
   /**
@@ -72,6 +89,11 @@ export interface MarkerProps extends ViewProps {
    * Expects one child - can be a View with multiple elements.
    */
   children: ReactElement;
+
+  /**
+   * Ref to access Marker methods.
+   */
+  ref?: Ref<MarkerRef>;
 }
 
 /**
@@ -87,16 +109,28 @@ export const Marker = ({
   id,
   anchor = "center",
   offset,
+  ref,
   ...props
 }: MarkerProps) => {
+  const nativeRef = useRef<NativeMarkerRef>(null);
+  const viewAnnotationRef = useRef<ViewAnnotationRef>(null);
+
   const nativeAnchor = anchorToNative(anchor);
   const nativeOffset = offset ? { x: offset[0], y: offset[1] } : undefined;
 
   const frozenId = useFrozenId(id);
 
+  useImperativeHandle(ref, () => ({
+    getAnimatableRef: () =>
+      Platform.OS === "ios"
+        ? (viewAnnotationRef.current?.getAnimatableRef() as NativeMarkerRef | null)
+        : nativeRef.current,
+  }));
+
   if (Platform.OS === "ios") {
     return (
       <ViewAnnotation
+        ref={viewAnnotationRef}
         id={frozenId}
         anchor={anchor}
         offset={offset}
@@ -107,6 +141,7 @@ export const Marker = ({
 
   return (
     <MarkerViewNativeComponent
+      ref={nativeRef}
       id={frozenId}
       anchor={nativeAnchor}
       offset={nativeOffset}

--- a/package/src/components/annotations/view-annotation/ViewAnnotation.tsx
+++ b/package/src/components/annotations/view-annotation/ViewAnnotation.tsx
@@ -148,6 +148,11 @@ export interface ViewAnnotationRef {
    * Call this for example from Image#onLoad.
    */
   refresh(): void;
+  /**
+   * Returns the native ref for Reanimated v4 compatibility.
+   * Uses a Proxy to map _viewConfig to __viewConfig.
+   */
+  getAnimatableRef(): NativeViewAnnotationRef | null;
 }
 
 /**
@@ -178,6 +183,16 @@ export const ViewAnnotation = ({
         Commands.refresh(nativeRef.current);
       }
     },
+    // Reanimated v4 compatibility: createAnimatedComponent looks for _viewConfig but native has __viewConfig
+    getAnimatableRef: () =>
+      nativeRef.current
+        ? new Proxy(nativeRef.current, {
+            get: (target, prop) =>
+              prop === "_viewConfig"
+                ? (target as unknown as { __viewConfig: unknown }).__viewConfig
+                : target[prop as keyof typeof target],
+          })
+        : null,
   }));
 
   const wrappedChildren = (() => {

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -125,6 +125,7 @@ export {
   type NativeMarkerRef,
   type MarkerEvent,
   type MarkerProps,
+  type MarkerRef,
   Marker,
 } from "./components/annotations/marker/Marker";
 


### PR DESCRIPTION
Implement getAnimatableRef() method on ViewAnnotation and Marker to support react-native-reanimated v4's createAnimatedComponent.

Reanimated v4 requires getAnimatableRef() on components using useImperativeHandle. The native ref also needs _viewConfig mapped to __viewConfig via Proxy for Reanimated's internal checks.

- Add getAnimatableRef() to ViewAnnotationRef interface
- Add MarkerRef interface with getAnimatableRef()
- On iOS, Marker delegates to ViewAnnotation.getAnimatableRef()
- On Android, Marker returns the native ref directly
- Export MarkerRef from package index

Closes #1302