### PR TITLE
fix(ios): preserve native annotation drag for custom view annotations

### DIFF
--- a/package/ios/components/annotations/point-annotation/MLRNPointAnnotation.m
+++ b/package/ios/components/annotations/point-annotation/MLRNPointAnnotation.m
@@ -9,6 +9,9 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 
 @implementation MLRNPointAnnotation {
   UITapGestureRecognizer *customViewTap;
+  // Finger-to-anchor offset to preserve the touch position relative to the annotation's anchor
+  CGPoint _dragFingerOffset;
+  BOOL _dragFingerOffsetCaptured;
 }
 
 - (id)init {
@@ -37,6 +40,11 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 }
 
 - (void)reactSetFrame:(CGRect)frame {
+  // Skip frame updates while dragging
+  if (self.dragState != MLNAnnotationViewDragStateNone) {
+    return;
+  }
+
   if ([_map.annotations containsObject:self]) {
     [_map removeAnnotation:self];
   }
@@ -53,6 +61,36 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
 - (void)setOffset:(NSDictionary<NSString *, NSNumber *> *)offset {
   _offset = offset;
   [self _setCenterOffset:self.frame];
+}
+
+- (void)setCenter:(CGPoint)center {
+  // Reset drag offset tracking whenever we're not in a drag
+  if (self.dragState == MLNAnnotationViewDragStateNone) {
+    _dragFingerOffsetCaptured = NO;
+    [super setCenter:center];
+    return;
+  }
+
+  if (_map != nil) {
+    CGPoint coordPoint = [_map convertCoordinate:self.coordinate toPointToView:_map];
+
+    // Reject map-redraw resets: MapLibre re-projects annotations from their
+    // coordinate on every redraw, snapping the view back mid-drag.
+    if (fabs(center.x - coordPoint.x) < 0.5 && fabs(center.y - coordPoint.y) < 0.5) {
+      return;
+    }
+
+    // Capture the finger-to-anchor offset so the view doesn't snap its center
+    // to the touch point, preserving where the user grabbed relative to the anchor.
+    if (!_dragFingerOffsetCaptured) {
+      _dragFingerOffset = CGPointMake(center.x - coordPoint.x, center.y - coordPoint.y);
+      _dragFingerOffsetCaptured = YES;
+    }
+    center.x -= _dragFingerOffset.x;
+    center.y -= _dragFingerOffset.y;
+  }
+
+  [super setCenter:center];
 }
 
 - (void)setMap:(MLNMapView *)map {
@@ -151,6 +189,7 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
       }
     }
     [self addGestureRecognizer:customViewTap];
+    self.annotation = self;
     return self;
   }
 }


### PR DESCRIPTION
This pull request fixes 3 bugs with dragging annotations, and adds a feature that preserves the original finger offset when dragging the annotation (instead of assuming the finger position should be unprojected to lng/lat).

In it's current form, a draggable ViewAnnotation/Marker with a custom React Native view child is unusable: depending on which bug triggers first, the drag either never responds, snaps back to origin mid-drag, or crashes the app.

Three interacting bugs, all in MLRNPointAnnotation.m, all needed together:

1. `self.annotation` is never set in the custom-view path.

   getAnnotationView returns `self` (MLRNPointAnnotation is both MLNAnnotation and MLNAnnotationView). For the default-pin path MapLibre creates a separate MLNAnnotationView and binds it to the annotation, but in the custom-view path the returned view's `annotation` property is never set. MLNAnnotationView's native drag (setDragState:) dereferences self.annotation and throws `NSInvalidArgumentException: Annotation property should not be nil.`

   Fix: assign `self.annotation = self` before returning.

2. reactSetFrame: removes and re-adds the annotation on every Fabric commit, even during an active drag.

   The remove/add path nulls out view.annotation (via removeAnnotation:), cancelling the drag gesture recognizer. If a Fabric commit fires during the drag's Starting phase (which happens on every sibling re-render — e.g. a streaming GeoJSONSource update), the drag goes None → Starting → Canceling → None and never reaches Dragging.

   Fix: skip frame updates entirely when dragState != None. The annotation is already on the map at this point; the drag-end handler updates `coordinate`, which projects correctly on the next redraw after state returns to None.

3. Annotation view snaps back to origin on every map redraw during drag.

   MapLibre Native's annotation reposition path re-projects every annotation view from its `coordinate` property during a redraw and assigns the result to the view's `center`. The annotation's coordinate isn't updated until drag end, so the projection target is the original location. The reposition fights the drag gesture's own setCenter updates and the view visibly snaps back on every redraw. This is a MapLibre Native bug — it should skip annotations with dragState == Dragging.

   Fix: override setCenter: to detect and reject reposition attempts that match the current coordinate's projection while a drag is in progress. The drag gesture's own setCenter calls (which use the touch position) pass through normally.

Reproduction (before any fix applied):

1. Add a draggable ViewAnnotation/Marker with a custom React Native view child to a map.
2. Add any GeoJSONSource with frequently updating data (e.g. AIS feed, animated layer).
3. Long-press the annotation to start dragging.
4. Result: crash, no movement, or snap-back depending on which bug wins.