### PR TITLE
fix(iOS): avoid duplicate MapLibre.xcframework-ios.signature for Expo and RN

### DIFF
--- a/examples/react-native-app/ios/MapLibreReactNativeExample.xcodeproj/project.pbxproj
+++ b/examples/react-native-app/ios/MapLibreReactNativeExample.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */,
 				E235C05ADACE081382539298 /* [CP] Copy Pods Resources */,
+				5A5B4F56B14340D2489F6460 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
 			);
 			buildRules = (
 			);
@@ -205,6 +206,25 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MapLibreReactNativeExample/Pods-MapLibreReactNativeExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		5A5B4F56B14340D2489F6460 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
 		};
 		C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/package/MapLibreReactNative.podspec
+++ b/package/MapLibreReactNative.podspec
@@ -56,6 +56,15 @@ def $MLRN.post_install(installer)
           spm_spec[:requirement],
           spm_spec[:product_name]
         )
+        phase_name = "[MLRN] Remove duplicate MapLibre signature"
+        existing = user_target.shell_script_build_phases.find { |p| p.name == phase_name }
+        phase = existing || user_target.new_shell_script_build_phase(phase_name)
+        phase.shell_script = <<~SH
+          set -e
+          DUPE="${BUILT_PRODUCTS_DIR}/MapLibreReactNative/MapLibre.xcframework-ios.signature"
+          [ -f "$DUPE" ] && rm -f "$DUPE" || true
+        SH
+        phase.always_out_of_date = "1"
       end
     end
   end

--- a/package/MapLibreReactNative.podspec
+++ b/package/MapLibreReactNative.podspec
@@ -38,13 +38,31 @@ def $MLRN.post_install(installer)
   spm_spec = $MLRN_SPM_SPEC
 
   project = installer.pods_project
+  mlrn_target = project.targets.find { |t| t.name == "MapLibreReactNative" }
   self._add_spm_to_target(
     project,
-    project.targets.find { |t| t.name == "MapLibreReactNative"},
+    mlrn_target,
     spm_spec[:url],
     spm_spec[:requirement],
     spm_spec[:product_name]
   )
+  
+  if mlrn_target
+    phase_name = "[MLRN] Strip duplicate MapLibre signature (archive)"
+    existing = mlrn_target.shell_script_build_phases.find { |p| p.name == phase_name }
+    phase = existing || mlrn_target.new_shell_script_build_phase(phase_name)
+    phase.shell_script = <<~SH
+      # See MapLibreReactNative.podspec post_install for context.
+      if [ "$ACTION" = "install" ]; then
+        DUPE="${BUILT_PRODUCTS_DIR}/MapLibre.xcframework-ios.signature"
+        if [ -f "$DUPE" ]; then
+          echo "note: stripping duplicate $DUPE to avoid archive collision"
+          rm -f "$DUPE"
+        fi
+      fi
+    SH
+    phase.always_out_of_date = "1"
+  end
 
   installer.aggregate_targets.group_by(&:user_project).each do |project, targets|
     targets.each do |target|
@@ -56,15 +74,6 @@ def $MLRN.post_install(installer)
           spm_spec[:requirement],
           spm_spec[:product_name]
         )
-        phase_name = "[MLRN] Remove duplicate MapLibre signature"
-        existing = user_target.shell_script_build_phases.find { |p| p.name == phase_name }
-        phase = existing || user_target.new_shell_script_build_phase(phase_name)
-        phase.shell_script = <<~SH
-          set -e
-          DUPE="${BUILT_PRODUCTS_DIR}/MapLibreReactNative/MapLibre.xcframework-ios.signature"
-          [ -f "$DUPE" ] && rm -f "$DUPE" || true
-        SH
-        phase.always_out_of_date = "1"
       end
     end
   end

--- a/package/MapLibreReactNative.podspec
+++ b/package/MapLibreReactNative.podspec
@@ -46,23 +46,6 @@ def $MLRN.post_install(installer)
     spm_spec[:requirement],
     spm_spec[:product_name]
   )
-  
-  if mlrn_target
-    phase_name = "[MLRN] Strip duplicate MapLibre signature (archive)"
-    existing = mlrn_target.shell_script_build_phases.find { |p| p.name == phase_name }
-    phase = existing || mlrn_target.new_shell_script_build_phase(phase_name)
-    phase.shell_script = <<~SH
-      # See MapLibreReactNative.podspec post_install for context.
-      if [ "$ACTION" = "install" ]; then
-        DUPE="${BUILT_PRODUCTS_DIR}/MapLibre.xcframework-ios.signature"
-        if [ -f "$DUPE" ]; then
-          echo "note: stripping duplicate $DUPE to avoid archive collision"
-          rm -f "$DUPE"
-        fi
-      fi
-    SH
-    phase.always_out_of_date = "1"
-  end
 
   installer.aggregate_targets.group_by(&:user_project).each do |project, targets|
     targets.each do |target|
@@ -74,6 +57,13 @@ def $MLRN.post_install(installer)
           spm_spec[:requirement],
           spm_spec[:product_name]
         )
+
+        phase_name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature"
+        unless user_target.shell_script_build_phases.any? { |p| p.name == phase_name }
+          phase = user_target.new_shell_script_build_phase(phase_name)
+          phase.shell_script = 'rm -rf "$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature"'
+          phase.always_out_of_date = "1"
+        end
       end
     end
   end

--- a/package/src/plugin/ios.ts
+++ b/package/src/plugin/ios.ts
@@ -87,47 +87,6 @@ export const withPodfileGlobalVariables: ConfigPlugin<MapLibrePluginProps> = (
   });
 };
 
-const withoutSignatures: ConfigPlugin = (config) => {
-  return withXcodeProject(config, (c) => {
-    const project = c.modResults;
-    const targetName = c.modRequest.projectName;
-    const phaseName =
-      "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
-
-    const nativeTargetId = project.findTargetKey(targetName ?? "");
-    if (!nativeTargetId) {
-      console.warn(
-        `[MapLibre React Native] Could not find target "${targetName}" to add build phase script`,
-      );
-      return c;
-    }
-
-    const buildPhases =
-      project.pbxNativeTargetSection()[nativeTargetId]?.buildPhases ?? [];
-    const alreadyExists = buildPhases.some(
-      (phase: { comment?: string }) => phase.comment === phaseName,
-    );
-
-    if (!alreadyExists) {
-      project.addBuildPhase(
-        [],
-        "PBXShellScriptBuildPhase",
-        phaseName,
-        nativeTargetId,
-        {
-          shellPath: "/bin/sh",
-          shellScript: `
-          echo "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
-          rm -rf "$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature";
-        `,
-        },
-      );
-    }
-
-    return c;
-  });
-};
-
 /**
  * Set the Debug Information Format to DWARF with dSYM File during EAS Build for
  * Managed App https://github.com/expo/eas-cli/issues/968
@@ -151,6 +110,5 @@ const withDwarfDsym: ConfigPlugin = (config) => {
 export const ios = {
   withPodfilePostInstall,
   withPodfileGlobalVariables,
-  withoutSignatures,
   withDwarfDsym,
 };

--- a/package/src/plugin/withMapLibre.ts
+++ b/package/src/plugin/withMapLibre.ts
@@ -19,7 +19,6 @@ const withMapLibre: ConfigPlugin<MapLibrePluginProps> = (config, props) => {
 
   // iOS
   config = ios.withDwarfDsym(config);
-  config = ios.withoutSignatures(config);
   config = ios.withPodfileGlobalVariables(config, props);
   config = ios.withPodfilePostInstall(config);
 


### PR DESCRIPTION
Fixes #1488
Fixes #1489

This pull request updates the `post_install` hook in the `MapLibreReactNative.podspec` to add a new shell script build phase that removes a duplicate MapLibre signature file during the archive step. This helps prevent archive collisions caused by duplicate signature files.

Build process improvements:

* Adds a shell script build phase to the `MapLibreReactNative` target that removes the duplicate `MapLibre.xcframework-ios.signature` file during the install action to avoid archive collisions. The script is only added if it doesn't already exist, ensuring idempotency.