### PR TITLE
fix(iOS): avoid UUID collision when injecting SPM

### DIFF
--- a/package/MapLibreReactNative.podspec
+++ b/package/MapLibreReactNative.podspec
@@ -15,19 +15,35 @@ $MLRN_SPM_SPEC ||= {
 
 $MLRN = Object.new
 
+# Allocate a fresh UUID that does not collide with any existing object in the
+# Pods project. CocoaPods' counter-based UUID generator can be reset between
+# project generation and post_install hooks, which causes `project.new(klass)`
+# to hand out a UUID already used by PBXProject and silently overwrite it.
+def $MLRN._mlrn_unique_uuid(project)
+  require "securerandom"
+  loop do
+    candidate = SecureRandom.hex(12).upcase
+    return candidate unless project.objects_by_uuid.key?(candidate)
+  end
+end
+
 def $MLRN._add_spm_to_target(project, target, url, requirement, product_name)
   pkg_class = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference
   ref_class = Xcodeproj::Project::Object::XCSwiftPackageProductDependency
   pkg = project.root_object.package_references.find { |p| p.class == pkg_class && p.repositoryURL == url }
   if !pkg
-    pkg = project.new(pkg_class)
+    pkg_uuid = self._mlrn_unique_uuid(project)
+    pkg = pkg_class.new(project, pkg_uuid)
+    project.objects_by_uuid[pkg_uuid] = pkg
     pkg.repositoryURL = url
     project.root_object.package_references << pkg
   end
   pkg.requirement = requirement
   ref = target.package_product_dependencies.find { |r| r.class == ref_class && r.package == pkg && r.product_name == product_name }
   if !ref
-    ref = project.new(ref_class)
+    ref_uuid = self._mlrn_unique_uuid(project)
+    ref = ref_class.new(project, ref_uuid)
+    project.objects_by_uuid[ref_uuid] = ref
     ref.package = pkg
     ref.product_name = product_name
     target.package_product_dependencies << ref

--- a/package/MapLibreReactNative.podspec
+++ b/package/MapLibreReactNative.podspec
@@ -1,4 +1,5 @@
 require "json"
+require "securerandom"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
@@ -15,12 +16,8 @@ $MLRN_SPM_SPEC ||= {
 
 $MLRN = Object.new
 
-# Allocate a fresh UUID that does not collide with any existing object in the
-# Pods project. CocoaPods' counter-based UUID generator can be reset between
-# project generation and post_install hooks, which causes `project.new(klass)`
-# to hand out a UUID already used by PBXProject and silently overwrite it.
+# Prevent UUID collisions https://github.com/maplibre/maplibre-react-native/issues/1499
 def $MLRN._mlrn_unique_uuid(project)
-  require "securerandom"
   loop do
     candidate = SecureRandom.hex(12).upcase
     return candidate unless project.objects_by_uuid.key?(candidate)


### PR DESCRIPTION
## Description

Fixes maplibre/maplibre-react-native#1499

CocoaPods' counter-based UUID generator (`46EB2E…` prefix from `SHA256("Pods.xcodeproj")`) is reset between project generation and `post_install` hooks. The first call to `project.new(klass)` inside `_add_spm_to_target` then returns `46EB2E00000000` — the same UUID `PBXProject` already owns — and the new `XCRemoteSwiftPackageReference` silently overwrites the `PBXProject` block.

The corrupted `Pods.xcodeproj` still loads partially in Xcode: pods with cached `xcconfig` paths build by luck, but targets that need the full project graph (codegen-driven modules) silently fail to produce their `.a`. The linker error surfaces on whichever pod gets pulled in first, e.g. `library 'RNShare' not found`, pointing far away from the real cause.

## Fix

Replace `project.new(klass)` with explicit UUIDs allocated via `SecureRandom.hex(12)`, verified against `project.objects_by_uuid` to guarantee uniqueness. Defensive change, no behavior difference in environments not affected by the counter reset.

## Verification

- Reproduced on Xcode 26 + CocoaPods 1.16.2 + xcodeproj 1.27.0 + new architecture.
- After the fix, `Pods.xcodeproj` keeps the `PBXProject` block intact (`rootObject = 46EB2E00000000` declared once, single `Begin PBXProject section`).
- Injected SPM objects now use random UUIDs (e.g. `B8BD2602B219FB3A2A310971` for `XCRemoteSwiftPackageReference`, `965AED2391B094FB9E9AD4F2` for `XCSwiftPackageProductDependency`).
- Validated with `pod install` in `examples/react-native-app/ios`. Build proceeds without phantom linker errors.

## Upstream Note

Underlying cause is in `cocoapods/xcodeproj` (counter reset behavior). A local fix in the podspec is appropriate as a defensive measure regardless of whether upstream chooses to address it, since the collision risk applies to any `post_install` hook calling `project.new`.
