### PR TITLE
fix(iOS): update Images after initial mount

### DIFF
--- a/package/ios/components/images/MLRNImages.h
+++ b/package/ios/components/images/MLRNImages.h
@@ -10,7 +10,7 @@
 @property (nonatomic, strong) MLRNMapView *_Nullable map;
 @property (nonatomic, strong, nonnull) NSMutableArray<id<RCTComponent>> *reactSubviews;
 
-@property (nonatomic, strong, nonnull) NSDictionary *images;
+@property (nonatomic, copy, nonnull) NSDictionary *images;
 
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onImageMissing;
 

--- a/package/ios/components/images/MLRNImages.m
+++ b/package/ios/components/images/MLRNImages.m
@@ -46,9 +46,21 @@ static UIImage *_placeHolderImage;
 }
 
 - (void)setImages:(NSDictionary *)images {
-  _images = images;
-  if (self.map != nil && self.map.style != nil) {
-    [self _processImages:_images];
+  NSDictionary *newImages = images != nil ? [images copy] : @{};
+  NSMutableDictionary *imagesToProcess = [NSMutableDictionary new];
+
+  for (NSString *imageName in newImages.allKeys) {
+    if (_images[imageName] == nil) {
+      imagesToProcess[imageName] = newImages[imageName];
+    }
+  }
+
+  NSMutableDictionary *mergedImages = _images ? [_images mutableCopy] : [NSMutableDictionary new];
+  [mergedImages addEntriesFromDictionary:newImages];
+  _images = [mergedImages copy];
+
+  if (self.map != nil && self.map.style != nil && imagesToProcess.count > 0) {
+    [self _processImages:imagesToProcess];
   }
 }
 

--- a/package/ios/components/images/MLRNImages.m
+++ b/package/ios/components/images/MLRNImages.m
@@ -45,6 +45,13 @@ static UIImage *_placeHolderImage;
   [self _processImages:_images];
 }
 
+- (void)setImages:(NSDictionary *)images {
+  _images = images;
+  if (self.map != nil && self.map.style != nil) {
+    [self _processImages:_images];
+  }
+}
+
 - (void)removeFromMap {
   if (self.map.style == nil) {
     return;

--- a/package/ios/components/map-view/MLRNMapView.m
+++ b/package/ios/components/map-view/MLRNMapView.m
@@ -182,6 +182,7 @@ static double const M2PI = M_PI * 2;
     camera.map = nil;
   } else if ([subview isKindOfClass:[MLRNImages class]]) {
     MLRNImages *images = (MLRNImages *)subview;
+    [images removeFromMap];
     images.map = nil;
     [_images removeObject:images];
   } else if ([subview isKindOfClass:[MLRNLayer class]]) {


### PR DESCRIPTION
## What

Fixes iOS `<Images />` prop updates after the map has mounted.

## Why

The Fabric component assigned updated `images` props to `MLRNImages`, but `MLRNImages` only processed images from `addToMap`. Async image entries added after mount were not registered in the style on iOS, while Android already processes new entries from its setter.

## Testing

- Tested in a React Native app using `@maplibre/maplibre-react-native@11.2.1`: icons downloaded after map mount render on iOS without restarting the app.
- `git diff --check`

Note: I could not run `clang-format` locally because it is not installed in this environment.