### PR TITLE
feat(iOS): upgrade MapLibre Native to 6.26.0

### DIFF
--- a/docs/content/setup/getting-started.md
+++ b/docs/content/setup/getting-started.md
@@ -17,7 +17,7 @@ This package wraps MapLibre Native for Android and iOS, these are the currently 
     </dd>
     <dt>iOS</dt>
     <dd>
-      <a href="https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.25.0">6.25.0</a>
+      <a href="https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.26.0">6.26.0</a>
     </dd>
 </dl>
 

--- a/examples/react-native-app/ios/MapLibreReactNativeExample.xcodeproj/project.pbxproj
+++ b/examples/react-native-app/ios/MapLibreReactNativeExample.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
 				kind = exactVersion;
-				version = 6.25.0;
+				version = 6.26.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/react-native-app/ios/MapLibreReactNativeExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/react-native-app/ios/MapLibreReactNativeExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "e70d3525c8e2819a8b34f22909815dab5c700c25a06c32388f3930f7b3627768",
+  "originHash" : "b440cbd994821d1c59ef3fae39cdd359458004248a336c94f8a8b08f5fed3877",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
       "state" : {
-        "revision" : "e0ee2c11a2859e22d3f0dd29705c18169bdafa7b",
-        "version" : "6.25.0"
+        "revision" : "be0696007ca8b350faa0e5968c0d6397d59db415",
+        "version" : "6.26.0"
       }
     }
   ],

--- a/package/MapLibreReactNative.podspec
+++ b/package/MapLibreReactNative.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 # Global Variable Defaults
-$MLRN_NATIVE_VERSION ||= "6.25.0"
+$MLRN_NATIVE_VERSION ||= "6.26.0"
 $MLRN_SPM_SPEC ||= {
   url: "https://github.com/maplibre/maplibre-gl-native-distribution",
   requirement: {


### PR DESCRIPTION
This release fixes many issues, https://github.com/maplibre/maplibre-gl-native-distribution/releases/tag/6.26.0

> core: Handle allocation failure (https://github.com/maplibre/maplibre-native/pull/4178).
> Disable icon scaling with offsets (https://github.com/maplibre/maplibre-native/pull/3928).
> Fix: unconditionally rewriting contentScaleFactor/drawableSize every layout pass caused a feedback loop under iOS 26 > Smart Display Zoom (https://github.com/maplibre/maplibre-native/pull/4251). This resolves CarPlay users were experiencing.
> iOS: Fix case image expression crash (#4269).