### PR TITLE
fix(Android): use getReactTag for react-native >= 0.87 compatibility

### DIFF
--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewManager.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewManager.kt
@@ -262,7 +262,7 @@ open class MLRNMapViewManager(
          * tearing down the views in onDropViewInstance.
          */
         fun disposeNativeMapView() {
-            val mapView = mViewManager.getByReactTag(reactTag)
+            val mapView = mViewManager.getByReactTag(getReactTag())
 
             if (mapView != null) {
                 UiThreadUtil.runOnUiThread {


### PR DESCRIPTION
Fixing RN nightlies that are now broken.
This change would be needed to make this library compatible with RN 0.87+

This change is also backward compatible with previous RN versions so is safe to merge and include in a `latest` release.