### PR TITLE
fix(android): guard stale map child indexes

### DIFF
--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
@@ -280,7 +280,7 @@ open class MLRNMapView(
     }
 
     fun removeFeature(childPosition: Int) {
-        val child = children()[childPosition]
+        val child = children().getOrNull(childPosition) ?: return
 
         when (child) {
             is MapChild.FeatureChild -> {
@@ -313,7 +313,7 @@ open class MLRNMapView(
 
     val featureCount: Int get() = children().size
 
-    fun getFeatureAt(i: Int): MapChild = children()[i]
+    fun getFeatureAt(i: Int): MapChild? = children().getOrNull(i)
 
     @Synchronized
     fun dispose() {

--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewManager.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewManager.kt
@@ -60,7 +60,7 @@ open class MLRNMapViewManager(
     override fun getChildAt(
         parent: MLRNMapView,
         index: Int,
-    ): View? = parent.getFeatureAt(index).toView()
+    ): View? = parent.getFeatureAt(index)?.toView()
 
     override fun removeViewAt(
         parent: MLRNMapView,


### PR DESCRIPTION
This fixes an Android crash where Fabric can ask MLRNMapView for a child index that is no longer present in the native map child list.
 
Previously, `getFeatureAt(index)` and `removeFeature(index)` accessed the list directly, which could throw `IndexOutOfBoundsException` and crash the app. This change uses safe index access and treats stale indexes as no-ops.

To be honest, not sure why we got that invalid indexes in the first place.