### PR TITLE
fix(android): shorten TransformRequestInterceptor log tag for SDK support

### DIFF
--- a/package/android/src/main/java/org/maplibre/reactnative/modules/TransformRequestInterceptor.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/modules/TransformRequestInterceptor.kt
@@ -177,7 +177,8 @@ class TransformRequestInterceptor : Interceptor {
 
     companion object {
         val INSTANCE: TransformRequestInterceptor = TransformRequestInterceptor()
-        private const val TAG = "TransformRequestInterceptor"
+        // Must be <= 23 chars: Log.isLoggable throws IllegalArgumentException on API <= 25.
+        private const val TAG = "MLRNTransformRequest"
 
         private fun matchDescription(matchRegex: Regex?) = if (matchRegex != null) " (match='${matchRegex.pattern}')" else ""
     }

--- a/package/android/src/main/java/org/maplibre/reactnative/modules/TransformRequestInterceptor.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/modules/TransformRequestInterceptor.kt
@@ -1,5 +1,6 @@
 package org.maplibre.reactnative.modules
 
+import android.os.Build
 import android.util.Log
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -177,8 +178,13 @@ class TransformRequestInterceptor : Interceptor {
 
     companion object {
         val INSTANCE: TransformRequestInterceptor = TransformRequestInterceptor()
-        // Must be <= 23 chars: Log.isLoggable throws IllegalArgumentException on API <= 25.
-        private const val TAG = "MLRNTransformRequest"
+        private val TAG by lazy {
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
+                "TransformReqInterceptor"
+            } else {
+                "TransformRequestInterceptor"
+            }
+        }
 
         private fun matchDescription(matchRegex: Regex?) = if (matchRegex != null) " (match='${matchRegex.pattern}')" else ""
     }


### PR DESCRIPTION
Log.isLoggable throws IllegalArgumentException for tags longer than 23 characters on API <= 25. Fixes #1417.

Pretty straightforward fix, used Claude - Opus for the investigation and fix