### PR TITLE
fix(iOS): serialize style image loads to avoid CUICatalog heap corruption

### DIFF
--- a/package/ios/components/images/MLRNImageQueueOperation.m
+++ b/package/ios/components/images/MLRNImageQueueOperation.m
@@ -111,7 +111,15 @@ typedef NS_ENUM(NSInteger, MLRNImageQueueOperationState) {
   }
 
   MLRNImageQueueOperation *strongSelf = self;
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+  // Serial queue: RCTImageLoader resolves bundle assets synchronously via +[UIImage imageNamed:],
+  // and concurrent lookups corrupt CUICatalog's cache. Network downloads still overlap.
+  static dispatch_queue_t imageLoadQueue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    imageLoadQueue = dispatch_queue_create("org.maplibre.reactnative.ImageQueueOperation",
+                                           DISPATCH_QUEUE_SERIAL);
+  });
+  dispatch_async(imageLoadQueue, ^{
     if (strongSelf.isCancelled) {
       return;
     }

--- a/package/ios/components/images/MLRNImageQueueOperation.m
+++ b/package/ios/components/images/MLRNImageQueueOperation.m
@@ -111,8 +111,6 @@ typedef NS_ENUM(NSInteger, MLRNImageQueueOperationState) {
   }
 
   MLRNImageQueueOperation *strongSelf = self;
-  // Serial queue: RCTImageLoader resolves bundle assets synchronously via +[UIImage imageNamed:],
-  // and concurrent lookups corrupt CUICatalog's cache. Network downloads still overlap.
   static dispatch_queue_t imageLoadQueue;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{


### PR DESCRIPTION
`MLRNImageQueueOperation` dispatches every image load onto the global concurrent queue. Local bundle assets resolve synchronously there via `+[UIImage imageNamed:]`, and dozens of concurrent lookups at map mount corrupt CUICatalog's lookup cache - malloc double-free in `-[NSCache setName:]` (SIGABRT).

Fix: dispatch all loads on a single serial queue. Network loads only serialize their kickoff, so downloads still overlap.

# AI disclosure

These fixes were developed with AI assistance (Claude Code - Fable 5) during production crash investigations; Tested and reviewed manually. Also, we released in as a patch for production VeloPlanner.