### PR TITLE
feat: add animated content inset updates

### DIFF
--- a/docs/content/components/map.md
+++ b/docs/content/components/map.md
@@ -604,6 +604,36 @@ Identifier of the target source-layer (e.g. 'building')
 await mapRef.current?.setSourceVisibility(false, "composite", "building");
 ```
 
+### `setContentInset(contentInset, [options])`
+
+Sets the distance from the map view's edges to its logical viewport. The
+inset persists across subsequent camera updates.
+
+#### `contentInset`
+
+The new logical viewport inset
+
+**Type:** `ViewPadding`
+
+**Required:** Yes
+
+#### `options`
+
+Transition options
+
+**Type:** `SetContentInsetOptions`
+
+**Required:** No
+
+**Returns:** `Promise<void>` — A promise that resolves once the native update has been scheduled.
+It does not wait for an animated transition to finish.
+
+**Animate the logical viewport above an overlay**
+
+```ts
+await mapRef.current?.setContentInset({ bottom: 300 }, { animated: true });
+```
+
 ### `showAttribution()`
 
 Show the attribution dialog
@@ -648,6 +678,21 @@ Event emitted when the map viewport changes (pan, zoom, rotate, pitch).
 type ViewStateChangeEvent = ViewState & {
   animated: boolean;
   userInteraction: boolean;
+};
+```
+
+### `SetContentInsetOptions`
+
+Options for changing the map's persistent logical viewport inset.
+
+```ts
+type SetContentInsetOptions = {
+  /**
+   * Whether to animate the change using the native default duration.
+   *
+   * @defaultValue false
+   */
+  animated?: boolean;
 };
 ```
 

--- a/examples/shared/src/examples/UserLocation/FollowUserLocationAlignment.tsx
+++ b/examples/shared/src/examples/UserLocation/FollowUserLocationAlignment.tsx
@@ -1,6 +1,6 @@
 import { Camera, Map, UserLocation } from "@maplibre/maplibre-react-native";
-import type { ViewPadding } from "@maplibre/maplibre-react-native";
-import { useState } from "react";
+import type { MapRef, ViewPadding } from "@maplibre/maplibre-react-native";
+import { useRef } from "react";
 
 import { TabBarView } from "@/components/TabBarView";
 import { MAPLIBRE_DEMO_STYLE } from "@/constants/MAPLIBRE_DEMO_STYLE";
@@ -17,7 +17,7 @@ const INSETS: Record<Alignment, ViewPadding | undefined> = {
 };
 
 export function FollowUserLocationAlignment() {
-  const [alignment, setAlignment] = useState<Alignment>(Alignment.Center);
+  const mapRef = useRef<MapRef>(null);
 
   return (
     <TabBarView
@@ -26,11 +26,13 @@ export function FollowUserLocationAlignment() {
         label: alignmentValue,
         data: alignmentValue,
       }))}
-      onOptionPress={(_index, data) => {
-        setAlignment(data);
+      onOptionPress={async (_index, data) => {
+        await mapRef.current?.setContentInset(INSETS[data] ?? {}, {
+          animated: true,
+        });
       }}
     >
-      <Map mapStyle={MAPLIBRE_DEMO_STYLE} contentInset={INSETS[alignment]}>
+      <Map ref={mapRef} mapStyle={MAPLIBRE_DEMO_STYLE}>
         <Camera trackUserLocation="default" zoom={6} />
         <UserLocation />
       </Map>

--- a/package/android/src/main/java/org/maplibre/reactnative/components/camera/CameraStop.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/camera/CameraStop.kt
@@ -57,7 +57,12 @@ class CameraStop {
         val paddingBottom: Int = contentInset[3].toInt() + paddingBottom
 
         val cameraPadding = intArrayOf(paddingLeft, paddingTop, paddingRight, paddingBottom)
-        val cameraPaddingClipped: IntArray = clippedPadding(cameraPadding, mapView)
+        val cameraPaddingClipped: IntArray =
+            getClippedCameraPadding(
+                cameraPadding,
+                mapView.width,
+                mapView.height,
+            )
 
         var hasSetZoom = false
 
@@ -172,42 +177,6 @@ class CameraStop {
             return stop
         }
 
-        private fun clippedPadding(
-            padding: IntArray,
-            mapView: MLRNMapView,
-        ): IntArray {
-            val mapHeight = mapView.height
-            val mapWidth = mapView.width
-
-            val left = padding[0]
-            val top = padding[1]
-            val right = padding[2]
-            val bottom = padding[3]
-
-            var resultLeft = left
-            var resultTop = top
-            var resultRight = right
-            var resultBottom = bottom
-
-            if (top + bottom >= mapHeight) {
-                val totalPadding = (top + bottom).toDouble()
-                val extra =
-                    totalPadding - mapHeight + 1.0 // Add 1 to compensate for floating point math
-                resultTop = (resultTop - (top * extra) / totalPadding).toInt()
-                resultBottom = (resultBottom - (bottom * extra) / totalPadding).toInt()
-            }
-
-            if (left + right >= mapWidth) {
-                val totalPadding = (left + right).toDouble()
-                val extra =
-                    totalPadding - mapWidth + 1.0 // Add 1 to compensate for floating point math
-                resultLeft = (resultLeft - (left * extra) / totalPadding).toInt()
-                resultRight = (resultRight - (right * extra) / totalPadding).toInt()
-            }
-
-            return intArrayOf(resultLeft, resultTop, resultRight, resultBottom)
-        }
-
         private fun getPaddingByKey(
             map: ReadableMap?,
             key: String,
@@ -220,4 +189,50 @@ class CameraStop {
             }
         }
     }
+}
+
+internal fun getClippedCameraPadding(
+    padding: IntArray,
+    mapWidth: Int,
+    mapHeight: Int,
+): IntArray =
+    getClippedCameraPadding(
+        DoubleArray(padding.size) { padding[it].toDouble() },
+        mapWidth,
+        mapHeight,
+    ).map { it.toInt() }.toIntArray()
+
+internal fun getClippedCameraPadding(
+    padding: DoubleArray,
+    mapWidth: Int,
+    mapHeight: Int,
+): DoubleArray {
+    require(padding.size == 4) { "Camera padding must contain left, top, right, and bottom values" }
+
+    val result = padding.copyOf()
+    clipPaddingPair(result, 1, 3, mapHeight)
+    clipPaddingPair(result, 0, 2, mapWidth)
+    return result
+}
+
+private fun clipPaddingPair(
+    padding: DoubleArray,
+    firstIndex: Int,
+    secondIndex: Int,
+    availableSize: Int,
+) {
+    if (availableSize <= 0) {
+        return
+    }
+
+    val first = padding[firstIndex]
+    val second = padding[secondIndex]
+    val total = first + second
+    if (total < availableSize || total <= 0) {
+        return
+    }
+
+    val extra = total - availableSize + 1.0
+    padding[firstIndex] = first - (first * extra) / total
+    padding[secondIndex] = second - (second * extra) / total
 }

--- a/package/android/src/main/java/org/maplibre/reactnative/components/location/LocationComponentManager.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/location/LocationComponentManager.kt
@@ -6,6 +6,7 @@ import org.maplibre.android.location.LocationComponent
 import org.maplibre.android.location.LocationComponentActivationOptions
 import org.maplibre.android.location.LocationComponentOptions
 import org.maplibre.android.location.OnCameraTrackingChangedListener
+import org.maplibre.android.location.OnLocationCameraTransitionListener
 import org.maplibre.android.location.modes.CameraMode
 import org.maplibre.android.location.modes.RenderMode
 import org.maplibre.android.maps.MapLibreMap
@@ -13,6 +14,16 @@ import org.maplibre.android.maps.Style
 import org.maplibre.reactnative.R
 import org.maplibre.reactnative.components.mapview.MLRNMapView
 import org.maplibre.reactnative.location.LocationManager
+
+private const val MAX_CAMERA_PADDING_RETRIES = 1
+
+private data class PendingCameraPadding(
+    val generation: Long,
+    val padding: DoubleArray,
+    val durationMs: Long,
+    val onTrackingUnavailable: () -> Unit,
+    val failedAttempts: Int = 0,
+)
 
 /**
  * The LocationComponent on android implements both location tracking and display of user's current location.
@@ -40,6 +51,19 @@ class LocationComponentManager(
 
     private var mOnCameraTrackingChangedListener: OnCameraTrackingChangedListener? = null
 
+    private var cameraModeTransitionGeneration = 0L
+    private var cameraModeTransitionInProgress = false
+    private var cameraPaddingGeneration = 0L
+    private var pendingCameraPadding: PendingCameraPadding? = null
+    private var activeCameraPadding: PendingCameraPadding? = null
+    private var cameraPaddingDrainScheduled = false
+    private var disposed = false
+    private val drainCameraPaddingRunnable =
+        Runnable {
+            cameraPaddingDrainScheduled = false
+            drainPendingCameraPadding()
+        }
+
     init {
         mMapView = mapView
         mMap = mMapView?.mapLibreMap
@@ -60,7 +84,73 @@ class LocationComponentManager(
     fun setCameraMode(
         @CameraMode.Mode cameraMode: Int,
     ) {
-        mLocationComponent?.cameraMode = cameraMode
+        if (disposed) {
+            return
+        }
+
+        val component = mLocationComponent ?: return
+        val transitionGeneration = ++cameraModeTransitionGeneration
+        cameraModeTransitionInProgress = true
+
+        component.setCameraMode(
+            cameraMode,
+            object : OnLocationCameraTransitionListener {
+                override fun onLocationCameraTransitionFinished(cameraMode: Int) {
+                    completeCameraModeTransition(transitionGeneration)
+                }
+
+                override fun onLocationCameraTransitionCanceled(cameraMode: Int) {
+                    completeCameraModeTransition(transitionGeneration)
+                }
+            },
+        )
+    }
+
+    fun trySetCameraPaddingWhileTracking(
+        padding: DoubleArray,
+        durationMs: Long,
+        onTrackingUnavailable: () -> Unit,
+    ): Boolean {
+        if (disposed) {
+            return false
+        }
+
+        val component = mLocationComponent ?: return false
+        val update =
+            PendingCameraPadding(
+                generation = ++cameraPaddingGeneration,
+                padding = padding.copyOf(),
+                durationMs = durationMs,
+                onTrackingUnavailable = onTrackingUnavailable,
+            )
+        pendingCameraPadding = update
+
+        if (cameraModeTransitionInProgress) {
+            return true
+        }
+
+        if (!isCameraTracking(component)) {
+            pendingCameraPadding = null
+            return false
+        }
+
+        drainPendingCameraPadding()
+        return true
+    }
+
+    fun cancelCameraPaddingAnimation() {
+        invalidateCameraPaddingUpdates()
+
+        val component = mLocationComponent
+        if (component?.isLocationComponentActivated == true) {
+            component.cancelPaddingWhileTrackingAnimation()
+        }
+    }
+
+    fun onCameraIdle() {
+        if (pendingCameraPadding != null) {
+            scheduleCameraPaddingDrain()
+        }
     }
 
     fun setRenderMode(
@@ -108,7 +198,7 @@ class LocationComponentManager(
             }
             mLocationComponent?.onStart()
         } else {
-            mLocationComponent?.cameraMode = CameraMode.NONE
+            setCameraMode(CameraMode.NONE)
         }
     }
 
@@ -138,7 +228,128 @@ class LocationComponentManager(
         }
 
         updateShowUserLocation(displayUserLocation)
+        drainPendingCameraPadding()
     }
+
+    private fun completeCameraModeTransition(generation: Long) {
+        if (disposed || generation != cameraModeTransitionGeneration) {
+            return
+        }
+
+        cameraModeTransitionInProgress = false
+        scheduleCameraPaddingDrain()
+    }
+
+    private fun drainPendingCameraPadding() {
+        if (disposed || cameraModeTransitionInProgress) {
+            return
+        }
+
+        val update = pendingCameraPadding ?: return
+        pendingCameraPadding = null
+        if (update.generation != cameraPaddingGeneration) {
+            return
+        }
+
+        val component = mLocationComponent
+        if (component != null && isCameraTracking(component)) {
+            startCameraPadding(component, update)
+        } else {
+            update.onTrackingUnavailable()
+        }
+    }
+
+    private fun startCameraPadding(
+        component: LocationComponent,
+        update: PendingCameraPadding,
+    ) {
+        activeCameraPadding = update
+        var terminalCallbackReceived = false
+        val callback =
+            object : MapLibreMap.CancelableCallback {
+                override fun onCancel() {
+                    if (terminalCallbackReceived) {
+                        return
+                    }
+
+                    terminalCallbackReceived = true
+                    if (disposed || update.generation != cameraPaddingGeneration || activeCameraPadding?.generation != update.generation) {
+                        return
+                    }
+
+                    activeCameraPadding = null
+                    pendingCameraPadding = update.copy(failedAttempts = update.failedAttempts + 1)
+                    if (update.failedAttempts < MAX_CAMERA_PADDING_RETRIES) {
+                        scheduleCameraPaddingDrain()
+                    }
+                }
+
+                override fun onFinish() {
+                    if (terminalCallbackReceived) {
+                        return
+                    }
+
+                    terminalCallbackReceived = true
+                    if (update.generation != cameraPaddingGeneration || activeCameraPadding?.generation != update.generation) {
+                        return
+                    }
+
+                    activeCameraPadding = null
+                    if (pendingCameraPadding?.generation == cameraPaddingGeneration) {
+                        scheduleCameraPaddingDrain()
+                    }
+                }
+            }
+
+        component.paddingWhileTracking(update.padding, update.durationMs, callback)
+    }
+
+    private fun scheduleCameraPaddingDrain() {
+        if (disposed || cameraPaddingDrainScheduled) {
+            return
+        }
+
+        val mapView = mMapView ?: return
+        cameraPaddingDrainScheduled = true
+        mapView.postOnAnimation(drainCameraPaddingRunnable)
+    }
+
+    private fun invalidateCameraPaddingUpdates() {
+        ++cameraPaddingGeneration
+        pendingCameraPadding = null
+        activeCameraPadding = null
+
+        if (cameraPaddingDrainScheduled) {
+            mMapView?.removeCallbacks(drainCameraPaddingRunnable)
+            cameraPaddingDrainScheduled = false
+        }
+    }
+
+    fun dispose() {
+        if (disposed) {
+            return
+        }
+
+        disposed = true
+        ++cameraModeTransitionGeneration
+        cameraModeTransitionInProgress = false
+        invalidateCameraPaddingUpdates()
+
+        val component = mLocationComponent
+        if (component?.isLocationComponentActivated == true) {
+            component.cancelPaddingWhileTrackingAnimation()
+        }
+        mOnCameraTrackingChangedListener?.let { component?.removeOnCameraTrackingChangedListener(it) }
+
+        mOnCameraTrackingChangedListener = null
+        mLocationComponent = null
+        mLocationManager = null
+        mMap = null
+        mMapView = null
+    }
+
+    private fun isCameraTracking(component: LocationComponent): Boolean =
+        component.isLocationComponentActivated && component.isLocationComponentEnabled && component.cameraMode != CameraMode.NONE
 
     private fun updateShowUserLocation(displayUserLocation: Boolean) {
         if (mShowingUserLocation != displayUserLocation) {

--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapView.kt
@@ -27,6 +27,8 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.EventDispatcher
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.camera.CameraUpdate
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.constants.MapLibreConstants
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.gestures.MoveGestureDetector
 import org.maplibre.android.log.Logger
@@ -53,6 +55,7 @@ import org.maplibre.reactnative.components.annotations.markerview.MLRNMarkerView
 import org.maplibre.reactnative.components.annotations.markerview.MarkerViewManager
 import org.maplibre.reactnative.components.annotations.pointannotation.MLRNPointAnnotation
 import org.maplibre.reactnative.components.camera.MLRNCamera
+import org.maplibre.reactnative.components.camera.getClippedCameraPadding
 import org.maplibre.reactnative.components.images.MLRNImages
 import org.maplibre.reactnative.components.layer.MLRNLayer
 import org.maplibre.reactnative.components.layer.style.MLRNStyle
@@ -85,6 +88,11 @@ sealed class MapChild {
             is ViewChild -> view
         }
 }
+
+private data class ContentInsetIdleRegistration(
+    val map: MapLibreMap,
+    val listener: MapLibreMap.OnCameraIdleListener,
+)
 
 open class MLRNMapView(
     context: Context,
@@ -135,7 +143,10 @@ open class MLRNMapView(
         private set
 
     private var mapStyle: String? = null
-    private var insets: ReadableArray? = null
+    private var contentInsetTarget = DoubleArray(4)
+    private var contentInsetGeneration = 0L
+    private var contentInsetIdleRegistration: ContentInsetIdleRegistration? = null
+    private var attachedToWindow = false
     private var preferredFramesPerSecond: Int? = null
 
     private var scrollEnabled: Boolean? = null
@@ -172,9 +183,15 @@ open class MLRNMapView(
     private var markerViewManager: MarkerViewManager? = null
     private var offscreenAnnotationViewContainer: ViewGroup? = null
 
-    val locationComponentManager: LocationComponentManager by lazy {
-        LocationComponentManager(this, context)
-    }
+    private val locationComponentManagerDelegate =
+        lazy {
+            LocationComponentManager(this, context)
+        }
+
+    val locationComponentManager: LocationComponentManager by locationComponentManagerDelegate
+
+    private val initializedLocationComponentManager: LocationComponentManager?
+        get() = if (locationComponentManagerDelegate.isInitialized()) locationComponentManagerDelegate.value else null
 
     val eventDispatcher: EventDispatcher?
         get() {
@@ -201,12 +218,15 @@ open class MLRNMapView(
     }
 
     override fun onDestroy() {
+        disposeContentInsetUpdates()
+        initializedLocationComponentManager?.dispose()
         super.onDestroy()
         destroyed = true
     }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        attachedToWindow = true
         ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
             windowInsets = insets
             updateUISettings()
@@ -214,9 +234,12 @@ open class MLRNMapView(
             insets
         }
         ViewCompat.requestApplyInsets(this)
+        updateInsets()
     }
 
     override fun onDetachedFromWindow() {
+        attachedToWindow = false
+        invalidateContentInsetUpdates()
         super.onDetachedFromWindow()
         ViewCompat.setOnApplyWindowInsetsListener(this, null)
     }
@@ -499,7 +522,10 @@ open class MLRNMapView(
             },
         )
 
-        mapLibreMap.addOnCameraIdleListener { sendRegionDidChangeEvent() }
+        mapLibreMap.addOnCameraIdleListener {
+            initializedLocationComponentManager?.onCameraIdle()
+            sendRegionDidChangeEvent()
+        }
     }
 
     fun reflow() {
@@ -597,6 +623,18 @@ open class MLRNMapView(
                 updateUISettings()
                 updateScaleBar()
             }
+        }
+    }
+
+    override fun onSizeChanged(
+        width: Int,
+        height: Int,
+        oldWidth: Int,
+        oldHeight: Int,
+    ) {
+        super.onSizeChanged(width, height, oldWidth, oldHeight)
+        if (width != oldWidth || height != oldHeight) {
+            updateInsets()
         }
     }
 
@@ -804,17 +842,31 @@ open class MLRNMapView(
     }
 
     fun setReactContentInset(value: ReadableMap?) {
-        if (value != null) {
-            val arr = Arguments.createArray()
-            arr.pushDouble(if (value.hasKey("top")) value.getDouble("top") else 0.0)
-            arr.pushDouble(if (value.hasKey("right")) value.getDouble("right") else 0.0)
-            arr.pushDouble(if (value.hasKey("bottom")) value.getDouble("bottom") else 0.0)
-            arr.pushDouble(if (value.hasKey("left")) value.getDouble("left") else 0.0)
-            insets = arr
-        } else {
-            insets = null
-        }
+        updateContentInset(value)
         updateInsets()
+    }
+
+    fun setContentInset(
+        value: ReadableMap,
+        animated: Boolean,
+    ) {
+        updateContentInset(value)
+        updateInsets(animated)
+    }
+
+    private fun updateContentInset(value: ReadableMap?) {
+        val top = if (value?.hasKey("top") == true) value.getDouble("top") else 0.0
+        val right = if (value?.hasKey("right") == true) value.getDouble("right") else 0.0
+        val bottom = if (value?.hasKey("bottom") == true) value.getDouble("bottom") else 0.0
+        val left = if (value?.hasKey("left") == true) value.getDouble("left") else 0.0
+
+        contentInsetTarget =
+            doubleArrayOf(
+                left * displayDensity,
+                top * displayDensity,
+                right * displayDensity,
+                bottom * displayDensity,
+            )
     }
 
     fun setReactPreferredFramesPerSecond(preferredFramesPerSecond: Int?) {
@@ -1298,57 +1350,131 @@ open class MLRNMapView(
     }
 
     val contentInset: DoubleArray
-        get() {
-            if (insets == null) {
-                return doubleArrayOf(0.0, 0.0, 0.0, 0.0)
-            }
-            var top = 0.0
-            var right = 0.0
-            var bottom = 0.0
-            var left = 0.0
+        get() = contentInsetTarget.copyOf()
 
-            if (insets!!.size() == 4) {
-                top = insets!!.getInt(0).toDouble()
-                right = insets!!.getInt(1).toDouble()
-                bottom = insets!!.getInt(2).toDouble()
-                left = insets!!.getInt(3).toDouble()
-            } else if (insets!!.size() == 2) {
-                top = insets!!.getInt(0).toDouble()
-                right = insets!!.getInt(1).toDouble()
-                bottom = top
-                left = right
-            } else if (insets!!.size() == 1) {
-                top = insets!!.getInt(0).toDouble()
-                right = top
-                bottom = top
-                left = top
-            }
+    private fun updateInsets(animated: Boolean = false) {
+        val generation = ++contentInsetGeneration
+        removeContentInsetIdleListener()
 
-            return doubleArrayOf(
-                left * displayDensity,
-                top * displayDensity,
-                right * displayDensity,
-                bottom * displayDensity,
-            )
-        }
-
-    private fun updateInsets() {
-        if (this.mapLibreMap == null || insets == null) {
+        val map = mapLibreMap
+        if (destroyed || !attachedToWindow || map == null || width <= 0 || height <= 0) {
+            initializedLocationComponentManager?.cancelCameraPaddingAnimation()
             return
         }
 
-        val padding = this.contentInset
-        val top = padding[1]
-        val right = padding[2]
-        val bottom = padding[3]
-        val left = padding[0]
+        val padding =
+            getClippedCameraPadding(
+                contentInsetTarget,
+                width,
+                height,
+            )
+        val durationMs = if (animated) MapLibreConstants.ANIMATION_DURATION.toLong() else 0L
+        val updateWithoutTracking = {
+            if (generation == contentInsetGeneration) {
+                applyContentInsetWithoutTracking(
+                    map,
+                    padding,
+                    animated,
+                    generation,
+                )
+            }
+        }
 
-        mapLibreMap!!.setPadding(
-            left.toInt(),
-            top.toInt(),
-            right.toInt(),
-            bottom.toInt(),
-        )
+        if (initializedLocationComponentManager?.trySetCameraPaddingWhileTracking(
+                padding,
+                durationMs,
+                updateWithoutTracking,
+            ) != true
+        ) {
+            updateWithoutTracking()
+        }
+    }
+
+    private fun applyContentInsetWithoutTracking(
+        map: MapLibreMap,
+        padding: DoubleArray,
+        animated: Boolean,
+        generation: Long,
+    ) {
+        if (generation != contentInsetGeneration || map !== mapLibreMap || destroyed || !attachedToWindow) {
+            return
+        }
+
+        initializedLocationComponentManager?.cancelCameraPaddingAnimation()
+
+        val cameraUpdate = CameraUpdateFactory.paddingTo(padding)
+        var terminalCallbackReceived = false
+        val callback =
+            object : MapLibreMap.CancelableCallback {
+                override fun onCancel() {
+                    if (terminalCallbackReceived) {
+                        return
+                    }
+
+                    terminalCallbackReceived = true
+                    reconcileContentInsetOnNextCameraIdle(map, generation)
+                }
+
+                override fun onFinish() {
+                    terminalCallbackReceived = true
+                }
+            }
+
+        if (animated) {
+            map.easeCamera(
+                cameraUpdate,
+                MapLibreConstants.ANIMATION_DURATION,
+                true,
+                callback,
+            )
+        } else {
+            map.moveCamera(cameraUpdate, callback)
+        }
+    }
+
+    private fun reconcileContentInsetOnNextCameraIdle(
+        map: MapLibreMap,
+        generation: Long,
+    ) {
+        if (generation != contentInsetGeneration || map !== mapLibreMap || destroyed || !attachedToWindow) {
+            return
+        }
+
+        removeContentInsetIdleListener()
+
+        val listener =
+            object : MapLibreMap.OnCameraIdleListener {
+                override fun onCameraIdle() {
+                    val registration = contentInsetIdleRegistration
+                    if (registration?.listener !== this || registration.map !== map) {
+                        return
+                    }
+
+                    removeContentInsetIdleListener()
+                    if (generation == contentInsetGeneration) {
+                        updateInsets()
+                    }
+                }
+            }
+
+        contentInsetIdleRegistration = ContentInsetIdleRegistration(map, listener)
+        map.addOnCameraIdleListener(listener)
+    }
+
+    private fun removeContentInsetIdleListener() {
+        val registration = contentInsetIdleRegistration ?: return
+        contentInsetIdleRegistration = null
+        registration.map.removeOnCameraIdleListener(registration.listener)
+    }
+
+    private fun invalidateContentInsetUpdates() {
+        ++contentInsetGeneration
+        removeContentInsetIdleListener()
+        initializedLocationComponentManager?.cancelCameraPaddingAnimation()
+    }
+
+    private fun disposeContentInsetUpdates() {
+        invalidateContentInsetUpdates()
     }
 
     private fun setLifecycleListeners() {

--- a/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/mapview/MLRNMapViewModule.kt
@@ -4,6 +4,7 @@ import android.graphics.RectF
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import org.maplibre.android.MapLibre
 import org.maplibre.reactnative.NativeMapViewModuleSpec
@@ -174,6 +175,18 @@ class MLRNMapViewModule(
     ) {
         withViewportOnUIThread(reactTag, promise) {
             it.setSourceVisibility(visible, sourceId, sourceLayerId)
+            promise.resolve(null)
+        }
+    }
+
+    override fun setContentInset(
+        reactTag: Double,
+        contentInset: ReadableMap,
+        animated: Boolean,
+        promise: Promise,
+    ) {
+        withViewportOnUIThread(reactTag, promise) {
+            it.setContentInset(contentInset, animated)
             promise.resolve(null)
         }
     }

--- a/package/ios/components/map-view/MLRNMapView.h
+++ b/package/ios/components/map-view/MLRNMapView.h
@@ -116,4 +116,6 @@ typedef void (^StyleLoadedBlock)(MLNStyle *__nonnull style);
 
 - (void)notifyStyleLoaded;
 
+- (void)setReactContentInset:(UIEdgeInsets)contentInset animated:(BOOL)animated;
+
 @end

--- a/package/ios/components/map-view/MLRNMapView.m
+++ b/package/ios/components/map-view/MLRNMapView.m
@@ -14,6 +14,13 @@
 @implementation MLRNMapView {
   BOOL _pendingInitialLayout;
   CGPoint _lastTapPoint;
+  BOOL _isCameraChanging;
+  BOOL _isUpdatingContentInset;
+  BOOL _contentInsetReconciliationScheduled;
+  NSUInteger _contentInsetGeneration;
+  NSUInteger _activeContentInsetGeneration;
+  NSUInteger _pendingContentInsetReconciliationGeneration;
+  UIEdgeInsets _targetContentInset;
 }
 
 static double const DEG2RAD = M_PI / 180;
@@ -371,8 +378,134 @@ static double const M2PI = M_PI * 2;
   NSNumber *bottom = [reactContentInset valueForKey:@"bottom"];
   NSNumber *left = [reactContentInset valueForKey:@"left"];
 
-  self.contentInset =
+  UIEdgeInsets contentInset =
       UIEdgeInsetsMake(top.floatValue, left.floatValue, bottom.floatValue, right.floatValue);
+  [self setReactContentInset:contentInset animated:NO];
+}
+
+- (void)setReactContentInset:(UIEdgeInsets)contentInset animated:(BOOL)animated {
+  BOOL shouldRestartTrackingUpdate = _activeContentInsetGeneration != 0;
+  NSUInteger generation = ++_contentInsetGeneration;
+  _targetContentInset = contentInset;
+  _activeContentInsetGeneration = generation;
+  _pendingContentInsetReconciliationGeneration = 0;
+
+  [self normalizeContentInsetStateForTarget:contentInset
+                      restartTrackingUpdate:shouldRestartTrackingUpdate];
+
+  __weak __typeof__(self) weakSelf = self;
+  BOOL wasUpdatingContentInset = _isUpdatingContentInset;
+  _isUpdatingContentInset = YES;
+  [super setContentInset:contentInset
+                animated:animated
+       completionHandler:^{
+         __strong __typeof__(weakSelf) strongSelf = weakSelf;
+         if (strongSelf && generation == strongSelf->_contentInsetGeneration) {
+           [strongSelf completeContentInsetUpdateForGeneration:generation];
+         }
+       }];
+  _isUpdatingContentInset = wasUpdatingContentInset;
+}
+
+- (void)normalizeContentInsetStateForTarget:(UIEdgeInsets)targetContentInset
+                      restartTrackingUpdate:(BOOL)restartTrackingUpdate {
+  UIEdgeInsets cameraEdgeInsets = self.cameraEdgeInsets;
+  if (!UIEdgeInsetsEqualToEdgeInsets(self.contentInset, targetContentInset) ||
+      UIEdgeInsetsEqualToEdgeInsets(cameraEdgeInsets, targetContentInset) ||
+      (self.userTrackingMode != MLNUserTrackingModeNone && !restartTrackingUpdate)) {
+    return;
+  }
+
+  // MapLibre Native stores contentInset before its camera transition finishes. If that
+  // transition is interrupted, assigning the same target again otherwise becomes a no-op.
+  BOOL wasUpdatingContentInset = _isUpdatingContentInset;
+  _isUpdatingContentInset = YES;
+  [super setContentInset:cameraEdgeInsets animated:NO completionHandler:nil];
+  _isUpdatingContentInset = wasUpdatingContentInset;
+}
+
+- (void)completeContentInsetUpdateForGeneration:(NSUInteger)generation {
+  if (generation != _contentInsetGeneration || generation != _activeContentInsetGeneration) {
+    return;
+  }
+
+  if (generation == _pendingContentInsetReconciliationGeneration) {
+    // MapLibre Native also runs a transition's completion when it is cancelled.
+    [self scheduleContentInsetReconciliation];
+    return;
+  }
+
+  if (self.userTrackingMode != MLNUserTrackingModeNone ||
+      UIEdgeInsetsEqualToEdgeInsets(self.cameraEdgeInsets, _targetContentInset)) {
+    _activeContentInsetGeneration = 0;
+    _pendingContentInsetReconciliationGeneration = 0;
+    return;
+  }
+
+  _pendingContentInsetReconciliationGeneration = generation;
+  [self scheduleContentInsetReconciliation];
+}
+
+- (void)scheduleContentInsetReconciliation {
+  if (_contentInsetReconciliationScheduled) {
+    return;
+  }
+
+  _contentInsetReconciliationScheduled = YES;
+  __weak __typeof__(self) weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    __strong __typeof__(weakSelf) strongSelf = weakSelf;
+    if (!strongSelf) {
+      return;
+    }
+
+    strongSelf->_contentInsetReconciliationScheduled = NO;
+    if (strongSelf->_isCameraChanging) {
+      return;
+    }
+
+    NSUInteger generation = strongSelf->_pendingContentInsetReconciliationGeneration;
+    [strongSelf reconcileContentInsetForGeneration:generation];
+  });
+}
+
+- (void)reconcileContentInsetForGeneration:(NSUInteger)generation {
+  if (_isUpdatingContentInset || generation == 0 || generation != _contentInsetGeneration ||
+      generation != _pendingContentInsetReconciliationGeneration) {
+    return;
+  }
+
+  UIEdgeInsets cameraEdgeInsets = self.cameraEdgeInsets;
+  if (UIEdgeInsetsEqualToEdgeInsets(cameraEdgeInsets, _targetContentInset)) {
+    _activeContentInsetGeneration = 0;
+    _pendingContentInsetReconciliationGeneration = 0;
+    return;
+  }
+
+  _pendingContentInsetReconciliationGeneration = 0;
+  _isUpdatingContentInset = YES;
+  [self normalizeContentInsetStateForTarget:_targetContentInset restartTrackingUpdate:YES];
+
+  __weak __typeof__(self) weakSelf = self;
+  [super setContentInset:_targetContentInset
+                animated:NO
+       completionHandler:^{
+         __strong __typeof__(weakSelf) strongSelf = weakSelf;
+         if (strongSelf && generation == strongSelf->_contentInsetGeneration) {
+           [strongSelf completeContentInsetUpdateForGeneration:generation];
+         }
+       }];
+  _isUpdatingContentInset = NO;
+
+  if (generation != _contentInsetGeneration) {
+    return;
+  }
+
+  if (self.userTrackingMode == MLNUserTrackingModeNone &&
+      UIEdgeInsetsEqualToEdgeInsets(self.cameraEdgeInsets, _targetContentInset)) {
+    _activeContentInsetGeneration = 0;
+    _pendingContentInsetReconciliationGeneration = 0;
+  }
 }
 
 - (void)setReactPreferredFramesPerSecond:(NSInteger)reactPreferredFramesPerSecond {
@@ -747,7 +880,9 @@ static double const M2PI = M_PI * 2;
 - (void)mapView:(MLNMapView *)mapView
     regionWillChangeWithReason:(MLNCameraChangeReason)reason
                       animated:(BOOL)animated {
-  ((MLRNMapView *)mapView).isUserInteraction = (BOOL)(reason & ~MLNCameraChangeReasonProgrammatic);
+  MLRNMapView *reactMapView = (MLRNMapView *)mapView;
+  reactMapView->_isCameraChanging = YES;
+  reactMapView.isUserInteraction = (BOOL)(reason & ~MLNCameraChangeReasonProgrammatic);
   NSDictionary *viewState = [self makeViewState:mapView animated:animated];
 
   self.reactOnRegionWillChange(viewState);
@@ -762,12 +897,26 @@ static double const M2PI = M_PI * 2;
 - (void)mapView:(MLNMapView *)mapView
     regionDidChangeWithReason:(MLNCameraChangeReason)reason
                      animated:(BOOL)animated {
+  MLRNMapView *reactMapView = (MLRNMapView *)mapView;
+  reactMapView->_isCameraChanging = NO;
+
+  if (!reactMapView->_isUpdatingContentInset && reactMapView->_activeContentInsetGeneration != 0) {
+    NSUInteger generation = reactMapView->_activeContentInsetGeneration;
+    if ((reason & MLNCameraChangeReasonTransitionCancelled) ==
+        MLNCameraChangeReasonTransitionCancelled) {
+      reactMapView->_pendingContentInsetReconciliationGeneration = generation;
+      [reactMapView scheduleContentInsetReconciliation];
+    } else {
+      [reactMapView completeContentInsetUpdateForGeneration:generation];
+    }
+  }
+
   if (((reason & MLNCameraChangeReasonTransitionCancelled) ==
        MLNCameraChangeReasonTransitionCancelled) &&
       ((reason & MLNCameraChangeReasonGesturePan) != MLNCameraChangeReasonGesturePan))
     return;
 
-  ((MLRNMapView *)mapView).isUserInteraction = (BOOL)(reason & ~MLNCameraChangeReasonProgrammatic);
+  reactMapView.isUserInteraction = (BOOL)(reason & ~MLNCameraChangeReasonProgrammatic);
 
   NSDictionary *viewState = [self makeViewState:mapView animated:animated];
 

--- a/package/ios/components/map-view/MLRNMapViewModule.mm
+++ b/package/ios/components/map-view/MLRNMapViewModule.mm
@@ -226,6 +226,26 @@
          methodName:@"showAttribution"];
 }
 
+- (void)setContentInset:(NSInteger)reactTag
+           contentInset:(JS::NativeMapViewModule::NativeViewPadding &)contentInset
+               animated:(BOOL)animated
+                resolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject {
+  UIEdgeInsets edgeInsets =
+      UIEdgeInsetsMake(contentInset.top().has_value() ? contentInset.top().value() : 0,
+                       contentInset.left().has_value() ? contentInset.left().value() : 0,
+                       contentInset.bottom().has_value() ? contentInset.bottom().value() : 0,
+                       contentInset.right().has_value() ? contentInset.right().value() : 0);
+
+  [self withMapView:reactTag
+              block:^(MLRNMapView *view) {
+                [view setReactContentInset:edgeInsets animated:animated];
+                resolve(nil);
+              }
+             reject:reject
+         methodName:@"setContentInset"];
+}
+
 - (void)setSourceVisibility:(NSInteger)reactTag
                     visible:(BOOL)visible
                      source:(nonnull NSString *)source

--- a/package/src/__tests__/__mocks__/NativeModules.mock.ts
+++ b/package/src/__tests__/__mocks__/NativeModules.mock.ts
@@ -48,6 +48,7 @@ export const mockNativeModules: Record<string, any> = {
     queryRenderedFeaturesWithBounds: jest.fn(),
     createStaticMapImage: jest.fn(),
     setSourceVisibility: jest.fn(),
+    setContentInset: jest.fn(),
     showAttribution: jest.fn(),
   },
 

--- a/package/src/__tests__/components/Map.test.tsx
+++ b/package/src/__tests__/components/Map.test.tsx
@@ -83,6 +83,7 @@ describe("Map", () => {
       expect(typeof mapRef.current.queryRenderedFeatures).toBe("function");
       expect(typeof mapRef.current.createStaticMapImage).toBe("function");
       expect(typeof mapRef.current.setSourceVisibility).toBe("function");
+      expect(typeof mapRef.current.setContentInset).toBe("function");
       expect(typeof mapRef.current.showAttribution).toBe("function");
     });
 
@@ -346,6 +347,28 @@ describe("Map", () => {
       expect(
         mockNativeModules.MLRNMapViewModule.setSourceVisibility,
       ).toHaveBeenCalledWith(expect.any(Number), true, "my-source", null);
+    });
+
+    test("setContentInset", async () => {
+      const { mapRef } = renderMap();
+      const contentInset = { top: 12, right: 16, bottom: 300, left: 16 };
+
+      await mapRef.current.setContentInset(contentInset, { animated: true });
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.setContentInset,
+      ).toHaveBeenCalledWith(expect.any(Number), contentInset, true);
+    });
+
+    test("setContentInset without animation", async () => {
+      const { mapRef } = renderMap();
+      const contentInset = { bottom: 300 };
+
+      await mapRef.current.setContentInset(contentInset);
+
+      expect(
+        mockNativeModules.MLRNMapViewModule.setContentInset,
+      ).toHaveBeenCalledWith(expect.any(Number), contentInset, false);
     });
 
     test("showAttribution", async () => {

--- a/package/src/components/map/Map.tsx
+++ b/package/src/components/map/Map.tsx
@@ -75,6 +75,18 @@ export type ViewStateChangeEvent = ViewState & {
 };
 
 /**
+ * Options for changing the map's persistent logical viewport inset.
+ */
+export type SetContentInsetOptions = {
+  /**
+   * Whether to animate the change using the native default duration.
+   *
+   * @defaultValue false
+   */
+  animated?: boolean;
+};
+
+/**
  * Options for querying rendered features at a screen point or within a bounding
  * box.
  */
@@ -266,6 +278,24 @@ export interface MapRef {
     visible: boolean,
     source: string,
     sourceLayer?: string,
+  ): Promise<void>;
+
+  /**
+   * Sets the distance from the map view's edges to its logical viewport. The
+   * inset persists across subsequent camera updates.
+   *
+   * @param contentInset - The new logical viewport inset
+   * @param options - Transition options
+   * @returns A promise that resolves once the native update has been scheduled. It does not wait for an animated transition to finish.
+   *
+   * @example Animate the logical viewport above an overlay
+   * ```ts
+   * await mapRef.current?.setContentInset({ bottom: 300 }, { animated: true });
+   * ```
+   */
+  setContentInset(
+    contentInset: ViewPadding,
+    options?: SetContentInsetOptions,
   ): Promise<void>;
 
   /**
@@ -644,6 +674,13 @@ export const Map = memo(
           visible,
           source,
           sourceLayer ?? null,
+        ),
+
+      setContentInset: (contentInset, options) =>
+        NativeMapViewModule.setContentInset(
+          findNodeHandle(nativeRef.current),
+          contentInset,
+          options?.animated ?? false,
         ),
 
       showAttribution: () =>

--- a/package/src/components/map/NativeMapViewModule.ts
+++ b/package/src/components/map/NativeMapViewModule.ts
@@ -12,6 +12,13 @@ type NativeViewState = {
   bounds: CodegenTypes.Double[];
 };
 
+type NativeViewPadding = {
+  top?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
+  right?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
+  bottom?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
+  left?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
+};
+
 export interface Spec extends TurboModule {
   getCenter: (
     reactTag: CodegenTypes.Int32,
@@ -65,6 +72,12 @@ export interface Spec extends TurboModule {
     visible: boolean,
     source: string,
     sourceLayer: string | null,
+  ) => Promise<void>;
+
+  setContentInset: (
+    reactTag: CodegenTypes.Int32,
+    contentInset: NativeViewPadding,
+    animated: boolean,
   ) => Promise<void>;
 
   createStaticMapImage: (

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -18,6 +18,7 @@ export {
 export {
   type ViewState,
   type ViewStateChangeEvent,
+  type SetContentInsetOptions,
   type MapRef,
   type MapProps,
   Map,


### PR DESCRIPTION
## Description

Related to #1559 and https://github.com/maplibre/maplibre-native/issues/2790.

Adds `MapRef.setContentInset(contentInset, { animated })`, an imperative API for persistent inset updates without re-rendering `MapView` or driving the native animation from JavaScript on every frame.

The native implementations:

- animate inset changes on iOS and Android while keeping the last requested inset as the persistent target;
- use latest-call-wins semantics for overlapping updates and lifecycle/style readiness;
- preserve user-location tracking instead of disabling it as a fallback;
- reconcile interrupted animations, including the iOS native same-target no-op tracked in https://github.com/maplibre/maplibre-native/issues/4449;
- retain the unclipped Android target and re-apply it when the viewport size changes.

The returned promise resolves after the native update has been scheduled; it does not wait for the animation to complete. The API documentation and shared example make that contract explicit.

## Validation

- TypeScript and ESLint checks
- Jest: 26 suites / 276 tests
- Bob package build
- Prettier, Kotlin lint, clang-format and generated-code diff checks
- Documentation typecheck/build
- Android example `compileDebugKotlin`
- iOS example simulator build against MapLibre Native 6.26.0

This repository does not currently expose a native unit-test harness for these map-view state machines, so the PR is intentionally left as a draft pending maintainer review and device-level interaction testing.

## Checklist

- [ ] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:eslint:fix` in the root folder
- [x] I have run tests via `yarn test` in the root folder
- [x] I updated the documentation with running `yarn codegen` in the root folder
- [x] I added/updated a sample (`/examples/shared`)

## Screenshot OR Video

Not included yet; this changes camera viewport behavior rather than rendered map styling.

## AI assistance disclosure

Substantial portions of this PR were developed with OpenAI Codex. The changes were manually reviewed, iterated against MapLibre Native behavior, and validated with the checks listed above.
