### PR TITLE
fix(android): keep location component padding when the puck is shown

### DIFF
--- a/package/android/src/main/java/org/maplibre/reactnative/components/location/LocationComponentManager.kt
+++ b/package/android/src/main/java/org/maplibre/reactnative/components/location/LocationComponentManager.kt
@@ -148,12 +148,12 @@ class LocationComponentManager(
     }
 
     fun options(displayUserLocation: Boolean): LocationComponentOptions {
-        var builder: LocationComponentOptions.Builder = LocationComponentOptions.builder(context)
+        var builder: LocationComponentOptions.Builder =
+            LocationComponentOptions.builder(context).padding(mMap?.getPadding())
         val tintColor = mMapView?.tintColor
         if (!displayUserLocation) {
             builder =
                 builder
-                    .padding(mMap?.getPadding())
                     .backgroundDrawable(R.drawable.empty)
                     .backgroundDrawableStale(R.drawable.empty)
                     .bearingDrawable(R.drawable.empty)


### PR DESCRIPTION
`LocationComponentManager.options()` applies the map padding only on the hidden puck branch, so turning on `showUserLocation` silently drops it:

```kotlin
var builder = LocationComponentOptions.builder(context)
val tintColor = mMapView?.tintColor
if (!displayUserLocation) {
    builder = builder
        .padding(mMap?.getPadding())   // only applied here
        .backgroundDrawable(R.drawable.empty)
        ...
} else if (tintColor != null) {
    // no padding
}
```

Simple patch to hoist the options builder so it's applied on both branches. We've been running this patch on Android for a while now so it's pretty much confirmed working.

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS <!-- Android only change; running in production since June -->
- [x] I formatted JS and TS files with running `yarn lint:eslint:fix` in the root folder <!-- no JS/TS changed; ktlint clean -->
- [x] I have run tests via `yarn test` in the root folder
- [x] I updated the documentation with running `yarn codegen` in the root folder <!-- no props changed -->
- [x] I added/updated a sample (`/examples/shared`) <!-- n/a -->

## AI Disclosure

I used Claude Code (Opus 5) while investigating and patching this.