### PR TITLE
fix(iOS): GeoJSONSource recycling

### DIFF
--- a/package/ios/components/sources/MLRNSource.m
+++ b/package/ios/components/sources/MLRNSource.m
@@ -103,6 +103,7 @@
 
   if (_source != nil) {
     [_map.style removeSource:_source];
+    _source = nil;
   }
 }
 

--- a/package/ios/components/sources/geojson-source/MLRNGeoJSONSourceComponentView.mm
+++ b/package/ios/components/sources/geojson-source/MLRNGeoJSONSourceComponentView.mm
@@ -62,6 +62,13 @@ using namespace facebook::react;
   return _view;
 }
 
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  static const auto defaultProps = std::make_shared<const MLRNGeoJSONSourceProps>();
+  _props = defaultProps;
+  [self prepareView];
+}
+
 #pragma mark - RCTComponentViewProtocol
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {


### PR DESCRIPTION
## Description

Fixes #1635

On iOS, a `<GeoJSONSource cluster>` triggers a crash because Fabric recycle native views, and GeoJSONSource leaves a stale source referenced by the view: the next non-clustered `<GeoJSONSource>` to mount, anywhere in the app, uses the recycled `MLRNGeoJSONSourceComponentView`, which still owns the previous component's `MLRNGeoJSONSource`, whose `_source` still points at the previous component's clustered `MLNShapeSource`. `updateProps` pushes the new `data` first, `setShape:` sees a non-nil source, and non-Point features reach supercluster, which throws `bad_variant_access` from C++ and the process aborts. The issue has a minimal reproduction with a control and the full analysis; the crash presented in our app as a SIGABRT with no JS error when users switched between dates on a view consisting of a clustered layer and a non-clustered layer. 

The issue is fixed by implementing `MLRNGeoJSONSrouceComponentView`, setting `_source = nil` in `MLRNSource.removeFromMap` as well as a more defensive change that drops non-Point features from a clustered collection. I am not sure if that is worth doing, and open to reverting that and the warning log.

Something else that Claude picked up is that cluster options are read only in `makeSource` and `MLNShapeSource` options are immutable, so `cluster` cannot be toggled after mount, and `updateProps` applies `data` before the cluster props and suggests recreating the source when those options change would fix that separately.

### Verification

- Standalone repro: https://github.com/michaelcohen-at/maplibre-rn-cluster-abort — `main` is the unpatched baseline, `fix/recycled-clustered-source` applies this exact diff via `patch-package`. With the fix: `repro`, `control` and `remount` sequences all complete; the polygon renders.
- In our app (Expo 57, RN 0.86, new architecture): the crash no longer reproduces when stepping a clustered layer through uncached data, across repeated unmount/remount cycles.
- iOS 26.4 simulator (iPhone 17 Pro). The original crash was also seen on iOS 26.6 and 26.6.1 devices.

### AI disclosure

Per the MapLibre AI policy: the analysis, the reproduction app, and the code in this PR were produced with Claude Code (Anthropic, Claude Fable 5) driven by me interactively. Initially Opus 5 was used but it it did not correctly reproduce the crash, with some direction (and poking) Fable 5 had better success. Fable proposed the diagnosis and wrote the Objective-C; I have reviewed every line and verified the behaviour on simulator. The reproduction and its control were designed to confirm the mechanism rather than infer a fix from crash logs.





.

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS — iOS only; this is iOS-only code. Android is unaffected (separate implementation).
- [x] I formatted JS and TS files with running `yarn lint:eslint:fix` in the root folder — no JS/TS changes; the Objective-C is formatted with the repo's `clang-format` config.
- [x] I have run tests via `yarn test` in the root folder
- [x] I updated the documentation with running `yarn codegen` in the root folder — no documented API changes.
- [ ] I added/updated a sample (`/examples/shared`) — the reproduction lives in its own repo (linked above); happy to add a sample if wanted.

## Screenshot OR Video

This video shows the reproduction crash and the control not-crash afterwards:

https://github.com/user-attachments/assets/3e0e59a1-f797-469d-8679-0aaa20944d88




This video shows the fix branch of the repro not-crashing with this PR's patch applied: 


https://github.com/user-attachments/assets/0939b51a-f0c5-4a6a-8f78-1ada3c5a6226


