### PR TITLE
fix(iOS): prevent NaN edge insets from _clippedPadding on zero-sized map view

### DIFF
--- a/package/ios/components/camera/CameraUpdateItem.m
+++ b/package/ios/components/camera/CameraUpdateItem.m
@@ -115,14 +115,17 @@
   double width = mapView.frame.size.width;
   double height = mapView.frame.size.height;
 
-  if ((padding.top + padding.bottom) >= height) {
+  // Skip clipping while the view has no size (e.g. first layout pass): with zero
+  // padding the division below yields 0/0 = NaN, which mbgl::EdgeInsets rejects
+  // by throwing, crashing the app.
+  if (height > 0 && (padding.top + padding.bottom) >= height) {
     double totalPadding = padding.top + padding.bottom;
     double extra = totalPadding - height + 1.0;
     result.top -= (padding.top * extra) / totalPadding;
     result.bottom -= (padding.bottom * extra) / totalPadding;
   }
 
-  if ((padding.left + padding.right) >= width) {
+  if (width > 0 && (padding.left + padding.right) >= width) {
     double totalPadding = padding.left + padding.right;
     double extra = totalPadding - width + 1.0;
     result.left -= (padding.left * extra) / totalPadding;

--- a/package/ios/components/camera/CameraUpdateItem.m
+++ b/package/ios/components/camera/CameraUpdateItem.m
@@ -115,9 +115,6 @@
   double width = mapView.frame.size.width;
   double height = mapView.frame.size.height;
 
-  // Skip clipping while the view has no size (e.g. first layout pass): with zero
-  // padding the division below yields 0/0 = NaN, which mbgl::EdgeInsets rejects
-  // by throwing, crashing the app.
   if (height > 0 && (padding.top + padding.bottom) >= height) {
     double totalPadding = padding.top + padding.bottom;
     double extra = totalPadding - height + 1.0;


### PR DESCRIPTION
Fixes #1620

## Problem

When a camera stop executes while the `MapView` frame is still zero-sized (e.g. the first layout pass inside a `ScrollView`, or a map mounted from a `transparentModal`), `_clippedPadding:forView:` runs its clipping math against `width`/`height` of `0`. With default padding this computes `0 / 0 = NaN`, the NaN reaches `-[MLNMapView camera:fittingCoordinateBounds:edgePadding:]`, and `mbgl::EdgeInsets` throws `std::domain_error` on NaN. The uncaught C++ exception escapes through UIKit layout and aborts the app (SIGABRT). Full symbolicated stack and repro in #1620.

Android is unaffected.

## Fix

Skip the clipping while the corresponding dimension is zero — clipping padding against a zero-sized frame is meaningless anyway, and the queued camera update re-runs once the view has its real size:

```objc
if (height > 0 && (padding.top + padding.bottom) >= height) { ... }
if (width > 0 && (padding.left + padding.right) >= width) { ... }
```

An alternative guard on the padding sum (`totalPadding > 0`, suggested in [this comment](https://github.com/maplibre/maplibre-react-native/issues/1620#issuecomment-5382581669)) also kills the `0/0`, and the two are equivalent for the observed crash (padding 0). They differ only for nonzero padding on a zero-sized view, and there the padding-sum guard doesn't actually "keep the clip working": with e.g. `top = bottom = 10` and `height = 0`, `extra (21)` exceeds `totalPadding (20)`, so the clip produces *negative* insets (−0.5/−0.5). For top/bottom the existing repair in `_makeCamera:` then bumps both to 1.0 — which still violates the padding-fits-in-view invariant the clip exists for (sum 2 on height 0) — and for left/right there is no such repair, so genuinely negative insets reach `edgePadding:` (mbgl accepts them but they invert the fitting geometry). The dimension guard never manufactures negative values and makes the division provably safe (`totalPadding >= height > 0` inside the block); clipping against a nonexistent frame is meaningless anyway, and the camera update re-runs once the view has laid out. Still happy to switch if you prefer the other form.

## Testing

- We've been shipping this exact change as a `patch-package` patch on 11.3.6 in production; the previously ~100 % reproducible crash on our summary screen (map in `ScrollView`) is gone, with no regressions in camera padding behavior on normally-sized maps.
- Reproduced the crash with the minimal snippet from #1620 before the fix; no crash after.

## AI disclosure

Per the [MapLibre AI policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md): this PR was prepared with assistance from Claude (Anthropic). The root-cause analysis, the fix, and the production validation are our own; all content has been reviewed by a human.
